### PR TITLE
feat(metrics): option for ignoring undefined routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ const OpenTelemetryModuleConfig = OpenTelemetryModule.forRoot({
       timeBuckets: [], // You can change the default time buckets
       defaultLabels: { // You can set default labels for api metrics
         custom: 'label'
-      }
+      },
+      ignoreUndefinedRoutes: false, //Records metrics for all URLs, even undefined ones
     },
   },
 });

--- a/src/interfaces/opentelemetry-options.interface.ts
+++ b/src/interfaces/opentelemetry-options.interface.ts
@@ -52,5 +52,6 @@ export type OpenTelemetryMetrics = {
     requestSizeBuckets?: number[],
     responseSizeBuckets?: number[],
     defaultLabels?: Labels,
+    ignoreUndefinedRoutes?: boolean,
   },
 };


### PR DESCRIPTION
This PR introduces a new option `ignoreUndefinedRoutes`. Enabling this option means any requests that do not match a route will not be recorded. This is to avoid a combinatorial explosion in the number of metrics generated by the microservice - Keeping cardinality low is best practice as documented on Prometheus' webpage (https://prometheus.io/docs/practices/naming/)

Note: Enabling this option when using Fastify means no metrics will be recorded as Fastify does not expose its routePath through Middleware. Fastify should probably be supported using Fastify's own hooks mechanism (https://www.fastify.io/docs/latest/Hooks/#onresponse) instead of using NestJS Middleware