### PR TITLE
revert: replace arrow function back with unnamed function

### DIFF
--- a/src/metrics/decorators/common.ts
+++ b/src/metrics/decorators/common.ts
@@ -39,8 +39,8 @@ export const OtelMethodCounter = (
   const description = `app_${className}#${propertyKey.toString()} called total`;
   let counterMetric: Counter;
   const methodFunc = descriptor.value;
-  // eslint-disable-next-line no-param-reassign
-  descriptor.value = (...args: any[]) => {
+  // eslint-disable-next-line no-param-reassign, func-names
+  descriptor.value = function (...args: any[]) {
     if (!counterMetric) {
       counterMetric = getOrCreateCounter(name, MetricType.Counter, { description, ...options });
     }


### PR DESCRIPTION
Arrow functions change `this` bahavior and thus cannot be used to decorate class methods. Revert back to the unnamed function and suppress eslint waring.

Fixes #129