### PR TITLE
fix(tracing): use startActiveSpan to ensure span in correct context

### DIFF
--- a/src/tracing/decorators/span.spec.ts
+++ b/src/tracing/decorators/span.spec.ts
@@ -1,6 +1,6 @@
 import { context, trace } from '@opentelemetry/api';
-import { Span } from './span';
 import { NodeSDK, tracing } from '@opentelemetry/sdk-node';
+import { Span } from './span';
 
 class TestSpan {
   @Span()

--- a/src/tracing/decorators/span.spec.ts
+++ b/src/tracing/decorators/span.spec.ts
@@ -1,0 +1,48 @@
+import { context, trace } from '@opentelemetry/api';
+import { Span } from './span';
+import { NodeSDK, tracing } from '@opentelemetry/sdk-node';
+
+class TestSpan {
+  @Span()
+  singleSpan() {
+    return trace.getSpan(context.active());
+  }
+
+  @Span()
+  doubleSpan() {
+    return this.singleSpan();
+  }
+}
+
+describe('Span', () => {
+  let instance: TestSpan;
+  let otelSdk: NodeSDK;
+
+  beforeEach(async () => {
+    instance = new TestSpan();
+
+    otelSdk = new NodeSDK({
+      traceExporter: new tracing.ConsoleSpanExporter(),
+      // Noop Span Processor disables any spans from being outputted
+      // by ConsoleSpanExporter.
+      // Remove it if you want to debug spans exported.
+      spanProcessor: new tracing.NoopSpanProcessor(),
+    });
+
+    await otelSdk.start();
+  });
+
+  afterEach(async () => {
+    await otelSdk.shutdown();
+  });
+
+  it('should set correct span', async () => {
+    const response = instance.singleSpan();
+    expect((response as any).name).toEqual('TestSpan.singleSpan');
+  });
+
+  it('should set correct span even when calling other method with Span decorator', async () => {
+    const response = instance.doubleSpan();
+    expect((response as any).name).toEqual('TestSpan.singleSpan');
+  });
+});

--- a/src/tracing/decorators/span.ts
+++ b/src/tracing/decorators/span.ts
@@ -1,21 +1,14 @@
-import { context, trace } from '@opentelemetry/api';
+import { trace } from '@opentelemetry/api';
 
 export function Span(name?: string) {
-  return (
-    target: any,
-    propertyKey: string,
-    propertyDescriptor: PropertyDescriptor,
-  ) => {
+  return (target: any, propertyKey: string, propertyDescriptor: PropertyDescriptor) => {
     const method = propertyDescriptor.value;
     // eslint-disable-next-line no-param-reassign
     propertyDescriptor.value = function PropertyDescriptor(...args: any[]) {
-      const currentSpan = trace.getSpan(context.active());
       const tracer = trace.getTracer('default');
+      const spanName = name || `${target.constructor.name}.${propertyKey}`;
 
-      return context.with(trace.setSpan(context.active(), currentSpan), () => {
-        const span = tracer.startSpan(
-          name || `${target.constructor.name}.${propertyKey}`,
-        );
+      return tracer.startActiveSpan(spanName, span => {
         if (method.constructor.name === 'AsyncFunction') {
           return method.apply(this, args).finally(() => {
             span.end();


### PR DESCRIPTION
Fixes #154
Fixes #165 

Current implementation didn't set span correctly to the context (see first commit and the test cases). The fix uses `startActiveSpan` helper to ensure span is created in active context.