### PR TITLE
fix: make sure decorators keep metadata

### DIFF
--- a/src/metrics/decorators/common.spec.ts
+++ b/src/metrics/decorators/common.spec.ts
@@ -1,0 +1,37 @@
+import 'reflect-metadata';
+import { SetMetadata } from '@nestjs/common';
+import { OtelInstanceCounter, OtelMethodCounter } from './common';
+
+const TestDecoratorThatSetsMetadata = () => SetMetadata('some-metadata', true);
+
+@OtelInstanceCounter()
+@TestDecoratorThatSetsMetadata()
+class TestClass {
+  @TestDecoratorThatSetsMetadata()
+  @OtelMethodCounter()
+  method() {}
+}
+
+describe('OtelInstanceCounter', () => {
+  let instance: TestClass;
+
+  beforeEach(() => {
+    instance = new TestClass();
+  });
+
+  it('should maintain reflect metadata', async () => {
+    expect(Reflect.getMetadata('some-metadata', instance.constructor)).toEqual(true);
+  });
+});
+
+describe('OtelMethodCounter', () => {
+  let instance: TestClass;
+
+  beforeEach(() => {
+    instance = new TestClass();
+  });
+
+  it('should maintain reflect metadata', async () => {
+    expect(Reflect.getMetadata('some-metadata', instance.method)).toEqual(true);
+  });
+});

--- a/src/metrics/decorators/common.ts
+++ b/src/metrics/decorators/common.ts
@@ -1,19 +1,22 @@
 import { Counter, MetricOptions } from '@opentelemetry/api-metrics';
+import { copyMetadataFromFunctionToFunction } from '../../opentelemetry.utils';
 import { getOrCreateCounter } from '../metric-data';
 
 /**
  * Create and increment a counter when a new instance is created
  *
- * @param ctor
+ * @param originalClass
  */
-export const OtelInstanceCounter = (
-  options?: MetricOptions,
-) => <T extends { new(...args: any[]): {} }>(ctor: T) => {
-  const name = `app_${ctor.name}_instances_total`;
-  const description = `app_${ctor.name} object instances total`;
+export const OtelInstanceCounter = (options?: MetricOptions) => <
+  T extends { new (...args: any[]): {} },
+>(
+    originalClass: T,
+  ) => {
+  const name = `app_${originalClass.name}_instances_total`;
+  const description = `app_${originalClass.name} object instances total`;
   let counterMetric: Counter;
 
-  return class extends ctor {
+  const wrappedClass = class extends originalClass {
     constructor(...args) {
       if (!counterMetric) {
         counterMetric = getOrCreateCounter(name, { description, ...options });
@@ -23,30 +26,36 @@ export const OtelInstanceCounter = (
       super(...args);
     }
   };
+
+  copyMetadataFromFunctionToFunction(originalClass, wrappedClass);
+
+  return wrappedClass;
 };
 
 /**
  * Create and increment a counter when the method is called
  */
-export const OtelMethodCounter = (
-  options?: MetricOptions,
-) => (
+export const OtelMethodCounter = (options?: MetricOptions) => (
   target: Object,
   propertyKey: string | symbol,
-  descriptor: TypedPropertyDescriptor<(...args: any[]
-  ) => any>,
+  descriptor: TypedPropertyDescriptor<(...args: any[]) => any>,
 ) => {
   const className = target.constructor.name;
   const name = `app_${className}_${propertyKey.toString()}_calls_total`;
   const description = `app_${className}#${propertyKey.toString()} called total`;
   let counterMetric: Counter;
-  const methodFunc = descriptor.value;
-  // eslint-disable-next-line no-param-reassign, func-names
-  descriptor.value = function (...args: any[]) {
+
+  const originalFunction = descriptor.value;
+
+  const wrappedFunction = function PropertyDescriptor(...args: any[]) {
     if (!counterMetric) {
       counterMetric = getOrCreateCounter(name, { description, ...options });
     }
     counterMetric.add(1);
-    return methodFunc.apply(this, args);
+    return originalFunction.apply(this, args);
   };
+  // eslint-disable-next-line no-param-reassign, func-names
+  descriptor.value = wrappedFunction;
+
+  copyMetadataFromFunctionToFunction(originalFunction, wrappedFunction);
 };

--- a/src/opentelemetry.utils.ts
+++ b/src/opentelemetry.utils.ts
@@ -1,0 +1,15 @@
+export const copyMetadataFromFunctionToFunction = (
+  originalFunction: Function,
+  newFunction: Function,
+): void => {
+  // Get the current metadata and set onto the wrapper
+  // to ensure other decorators ( ie: NestJS EventPattern / RolesGuard )
+  // won't be affected by the use of this instrumentation
+  Reflect.getMetadataKeys(originalFunction).forEach(metadataKey => {
+    Reflect.defineMetadata(
+      metadataKey,
+      Reflect.getMetadata(metadataKey, originalFunction),
+      newFunction,
+    );
+  });
+};

--- a/src/tracing/decorators/span.spec.ts
+++ b/src/tracing/decorators/span.spec.ts
@@ -1,7 +1,11 @@
+import 'reflect-metadata';
 import { SpanStatusCode } from '@opentelemetry/api';
 import { tracing } from '@opentelemetry/sdk-node';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { SetMetadata } from '@nestjs/common';
 import { Span } from './span';
+
+const TestDecoratorThatSetsMetadata = () => SetMetadata('some-metadata', true);
 
 class TestSpan {
   @Span()
@@ -16,6 +20,10 @@ class TestSpan {
   error() {
     throw new Error('hello world');
   }
+
+  @Span()
+  @TestDecoratorThatSetsMetadata()
+  metadata() {}
 }
 
 describe('Span', () => {
@@ -41,6 +49,10 @@ describe('Span', () => {
 
   afterAll(async () => {
     await provider.shutdown();
+  });
+
+  it('should maintain reflect metadataa', async () => {
+    expect(Reflect.getMetadata('some-metadata', instance.metadata)).toEqual(true);
   });
 
   it('should set correct span', async () => {


### PR DESCRIPTION
With current `@Span` decorators there is an issue that it breaks other decorators, such as `@OnEvent` from `@nestjs/event-emitter` module.

Similar to https://github.com/open-telemetry/opentelemetry-js-contrib/pull/796

Not sure how `@Controller` was working fine (as per e2e tests).