### PR TITLE
fix: forRootAsync uses the wrong module

### DIFF
--- a/src/opentelemetry-core.module.ts
+++ b/src/opentelemetry-core.module.ts
@@ -64,7 +64,7 @@ export class OpenTelemetryCoreModule implements OnApplicationBootstrap {
   static forRootAsync(options: OpenTelemetryModuleAsyncOptions): DynamicModule {
     const asyncProviders = this.createAsyncProviders(options);
     return {
-      module: OpenTelemetryModule,
+      module: OpenTelemetryCoreModule,
       imports: [...(options.imports || [])],
       providers: [
         ...asyncProviders,


### PR DESCRIPTION
`forRootAsync` did not work, because it used `OpenTelemetryModule` as a module instead of `OpenTelemetryCoreModule`