### PR TITLE
feat(tracing): pass options with span decorator

### DIFF
--- a/src/tracing/decorators/span.spec.ts
+++ b/src/tracing/decorators/span.spec.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { SpanStatusCode } from '@opentelemetry/api';
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import { tracing } from '@opentelemetry/sdk-node';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { SetMetadata } from '@nestjs/common';
@@ -15,6 +15,9 @@ class TestSpan {
   doubleSpan() {
     return this.singleSpan();
   }
+
+  @Span('foo', { kind: SpanKind.PRODUCER })
+  fooProducerSpan() {}
 
   @Span()
   error() {
@@ -62,6 +65,15 @@ describe('Span', () => {
 
     expect(spans).toHaveLength(1);
     expect(spans.map(span => span.name)).toEqual(['TestSpan.singleSpan']);
+  });
+
+  it('should set correct span options', async () => {
+    instance.fooProducerSpan();
+
+    const spans = traceExporter.getFinishedSpans();
+
+    expect(spans).toHaveLength(1);
+    expect(spans.map(span => span.kind)).toEqual([SpanKind.PRODUCER]);
   });
 
   it('should set correct span even when calling other method with Span decorator', async () => {

--- a/src/tracing/decorators/span.ts
+++ b/src/tracing/decorators/span.ts
@@ -1,4 +1,6 @@
-import { Span as ApiSpan, SpanStatusCode, trace } from '@opentelemetry/api';
+import {
+  Span as ApiSpan, SpanOptions, SpanStatusCode, trace,
+} from '@opentelemetry/api';
 import { copyMetadataFromFunctionToFunction } from '../../opentelemetry.utils';
 
 const recordException = (span: ApiSpan, error: any) => {
@@ -6,14 +8,14 @@ const recordException = (span: ApiSpan, error: any) => {
   span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
 };
 
-export function Span(name?: string) {
+export function Span(name?: string, options: SpanOptions = {}) {
   return (target: any, propertyKey: string, propertyDescriptor: PropertyDescriptor) => {
     const originalFunction = propertyDescriptor.value;
     const wrappedFunction = function PropertyDescriptor(...args: any[]) {
       const tracer = trace.getTracer('default');
       const spanName = name || `${target.constructor.name}.${propertyKey}`;
 
-      return tracer.startActiveSpan(spanName, span => {
+      return tracer.startActiveSpan(spanName, options, span => {
         if (originalFunction.constructor.name === 'AsyncFunction') {
           return originalFunction
             .apply(this, args)


### PR DESCRIPTION
This PR will allow to pass `SpanOptions` when using `@Span` decorator.