### PR TITLE
fix: getSpan returning undefined, enable strict null checks

### DIFF
--- a/src/metrics/decorators/common.ts
+++ b/src/metrics/decorators/common.ts
@@ -8,10 +8,8 @@ import { getOrCreateCounter } from '../metric-data';
  * @param originalClass
  */
 export const OtelInstanceCounter = (options?: MetricOptions) => <
-  T extends { new (...args: any[]): {} },
->(
-    originalClass: T,
-  ) => {
+  T extends { new(...args: any[]): {} },
+>(originalClass: T) => {
   const name = `app_${originalClass.name}_instances_total`;
   const description = `app_${originalClass.name} object instances total`;
   let counterMetric: Counter;
@@ -45,7 +43,7 @@ export const OtelMethodCounter = (options?: MetricOptions) => (
   const description = `app_${className}#${propertyKey.toString()} called total`;
   let counterMetric: Counter;
 
-  const originalFunction = descriptor.value;
+  const originalFunction = descriptor.value ?? (() => { });
 
   const wrappedFunction = function PropertyDescriptor(...args: any[]) {
     if (!counterMetric) {

--- a/src/metrics/metric-data.ts
+++ b/src/metrics/metric-data.ts
@@ -25,7 +25,7 @@ export const meterData: Map<string, GenericMetric> = new Map();
 
 export function getOrCreateHistogram(
   name: string,
-  options: MetricOptions,
+  options: MetricOptions = {},
 ): Histogram {
   if (meterData.has(name)) {
     return meterData.get(name) as Histogram;
@@ -39,7 +39,7 @@ export function getOrCreateHistogram(
 
 export function getOrCreateCounter(
   name: string,
-  options: MetricOptions,
+  options: MetricOptions = {},
 ): Counter {
   if (meterData.has(name)) {
     return meterData.get(name) as Counter;
@@ -54,7 +54,7 @@ export function getOrCreateCounter(
 
 export function getOrCreateUpDownCounter(
   name: string,
-  options: MetricOptions,
+  options: MetricOptions = {},
 ): UpDownCounter {
   if (meterData.has(name)) {
     return meterData.get(name) as UpDownCounter;
@@ -69,7 +69,7 @@ export function getOrCreateUpDownCounter(
 
 export function getOrCreateObservableGauge(
   name: string,
-  options: MetricOptions,
+  options: MetricOptions = {},
 ): ObservableGauge {
   if (meterData.has(name)) {
     return meterData.get(name) as ObservableGauge;
@@ -84,7 +84,7 @@ export function getOrCreateObservableGauge(
 
 export function getOrCreateObservableCounter(
   name: string,
-  options: MetricOptions,
+  options: MetricOptions = {},
 ): ObservableCounter {
   if (meterData.has(name)) {
     return meterData.get(name) as ObservableCounter;
@@ -99,7 +99,7 @@ export function getOrCreateObservableCounter(
 
 export function getOrCreateObservableUpDownCounter(
   name: string,
-  options: MetricOptions,
+  options: MetricOptions = {},
 ): ObservableUpDownCounter {
   if (meterData.has(name)) {
     return meterData.get(name) as ObservableUpDownCounter;

--- a/src/middleware/api-metrics.middleware.ts
+++ b/src/middleware/api-metrics.middleware.ts
@@ -39,7 +39,7 @@ export class ApiMetricsMiddleware implements NestMiddleware {
     const {
       defaultAttributes = {},
       ignoreUndefinedRoutes = false,
-    } = options?.metrics?.apiMetrics;
+    } = options?.metrics?.apiMetrics ?? {};
 
     this.defaultMetricAttributes = defaultAttributes;
     this.ignoreUndefinedRoutes = ignoreUndefinedRoutes;

--- a/src/tracing/trace.service.ts
+++ b/src/tracing/trace.service.ts
@@ -7,7 +7,7 @@ export class TraceService {
     return trace.getTracer('default');
   }
 
-  public getSpan(): Span {
+  public getSpan(): Span | undefined {
     return trace.getSpan(context.active());
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,13 @@
     "sourceMap": true,
     "outDir": "./lib",
     "baseUrl": "./",
-    "incremental": true
+    "incremental": true,
+    "strictNullChecks": true,
   },
-  "exclude": ["node_modules", "lib", "tests", "examples"]
+  "exclude": [
+    "node_modules",
+    "lib",
+    "tests",
+    "examples"
+  ]
 }


### PR DESCRIPTION
Fixes #360

This changes the public API and is thus a breaking change.

Also enables strict null checks for the whole TypeScript project, without changing the API.