### PR TITLE
Invalid values for error count metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ export class AppController {
 | ✅   | http.server.request.size            | http_server_request_size                  | Size of incoming bytes.                   | Histogram   |
 | ✅   | http.server.response.size           | http_server_response_size                 | Size of outgoing bytes.                   | Histogram   |
 | ✅   | http.server.response.success.count  | http_server_response_success_count_total  | Total number of all successful responses. | Counter     |
-| ✅   | http.server.response.error.count    | http_server_response_error_count_total    | Total number of all response errors'.     | Counter     |
+| ✅   | http.server.response.error.count    | http_server_response_error_count_total    | Total number of server error responses.   | Counter     |
 | ✅   | http.client.request.error.count     | http_client_request_error_count_total     | Total number of client error requests.    | Counter     |
 
 ## Prometheus Metrics

--- a/src/middleware/api-metrics.middleware.ts
+++ b/src/middleware/api-metrics.middleware.ts
@@ -132,12 +132,10 @@ export class ApiMetricsMiddleware implements NestMiddleware {
           this.httpServerResponseSuccessCount.add(1);
           break;
         case 'client_error':
-          this.httpServerResponseErrorCount.add(1);
           this.httpClientRequestErrorCount.add(1);
           break;
         case 'server_error':
           this.httpServerResponseErrorCount.add(1);
-          this.httpClientRequestErrorCount.add(1);
           break;
       }
 

--- a/tests/e2e/middleware/api-metrics.middleware.spec.ts
+++ b/tests/e2e/middleware/api-metrics.middleware.spec.ts
@@ -255,10 +255,12 @@ describe('Api Metrics Middleware', () => {
       }).compile();
 
       app = testingModule.createNestApplication();
+      app.useLogger(false);
+
       await app.init();
 
       const agent = request(app.getHttpServer());
-      await agent.get('/example/4/invalid-route?foo=bar');
+      await agent.get('/example/internal-error');
 
       // Workaround for delay of metrics going to prometheus
       await new Promise(resolve => setTimeout(resolve, 200));
@@ -286,11 +288,13 @@ describe('Api Metrics Middleware', () => {
       }).compile();
 
       app = testingModule.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+      app.useLogger(false);
+
       await app.init();
       await app.getHttpAdapter().getInstance().ready();
 
       const agent = request(app.getHttpServer());
-      await agent.get('/example/4/invalid-route?foo=bar');
+      await agent.get('/example/internal-error');
 
       // Workaround for delay of metrics going to prometheus
       await new Promise(resolve => setTimeout(resolve, 200));


### PR DESCRIPTION
`http.client.request.error.count` and `http.server.response.error.count` returned the same values instead of counting 4xx status code for the former and 5xx status codes for the later

Fixes pragmaticivan/nestjs-otel#425