### PR TITLE
fix: latency buckets are not matching the expected time unit in milliseconds

### DIFF
--- a/src/middleware/api-metrics.middleware.ts
+++ b/src/middleware/api-metrics.middleware.ts
@@ -118,7 +118,7 @@ export class ApiMetricsMiddleware implements NestMiddleware {
       this.httpServerResponseSize.record(responseLength, attributes);
 
       this.httpServerResponseCount.add(1, attributes);
-      this.httpServerDuration.record(time / 1000, attributes);
+      this.httpServerDuration.record(time, attributes);
 
       const codeClass = this.getStatusCodeClass(status);
 


### PR DESCRIPTION
fixes #449 