### PR TITLE
fix: `Span` being incompatible with `MethodDecorator` type

### DIFF
--- a/src/tracing/decorators/span.spec.ts
+++ b/src/tracing/decorators/span.spec.ts
@@ -6,6 +6,8 @@ import { Span } from './span';
 
 const TestDecoratorThatSetsMetadata = () => SetMetadata('some-metadata', true);
 
+const symbol = Symbol('testSymbol');
+
 class TestSpan {
   @Span()
   singleSpan() { }
@@ -26,6 +28,9 @@ class TestSpan {
   @Span()
   @TestDecoratorThatSetsMetadata()
   metadata() { }
+
+  @Span()
+  [symbol]() { }
 }
 
 describe('Span', () => {
@@ -113,5 +118,14 @@ describe('Span', () => {
       droppedAttributesCount: 0,
       time: expect.anything(),
     });
+  });
+
+  it('should handle symbols', () => {
+    instance[symbol]();
+
+    const spans = traceExporter.getFinishedSpans();
+
+    expect(spans).toHaveLength(1);
+    expect(spans.map(span => span.name)).toEqual(['TestSpan.Symbol(testSymbol)']);
   });
 });

--- a/src/tracing/decorators/span.ts
+++ b/src/tracing/decorators/span.ts
@@ -9,11 +9,11 @@ const recordException = (span: ApiSpan, error: any) => {
 };
 
 export function Span(name?: string, options: SpanOptions = {}) {
-  return (target: any, propertyKey: string, propertyDescriptor: PropertyDescriptor) => {
+  return (target: any, propertyKey: PropertyKey, propertyDescriptor: PropertyDescriptor) => {
     const originalFunction = propertyDescriptor.value;
     const wrappedFunction = function PropertyDescriptor(...args: any[]) {
       const tracer = trace.getTracer('default');
-      const spanName = name || `${target.constructor.name}.${propertyKey}`;
+      const spanName = name || `${target.constructor.name}.${String(propertyKey)}`;
 
       return tracer.startActiveSpan(spanName, options, span => {
         if (originalFunction.constructor.name === 'AsyncFunction') {


### PR DESCRIPTION
The decorator returned by `Span` specifies the `propertyKey` field as `string`, while the TypeScript `MethodDecorator` type requires it to allow `symbol` as well.

This is relevant as it can cause type conflicts when used with functions that expect a `MethodDecorator`. An example of this is the [decorate-all](https://www.npmjs.com/package/decorate-all) package used to apply a decorator to all methods of a class.

This PR updates the typing and adds a unit test for symbols.