### PR TITLE
feat: add dynamic labels

### DIFF
--- a/src/interfaces/opentelemetry-options.interface.ts
+++ b/src/interfaces/opentelemetry-options.interface.ts
@@ -41,11 +41,14 @@ export interface OpenTelemetryModuleAsyncOptions extends Pick<ModuleMetadata, 'i
   inject?: (string | symbol | Function | Type<any> | Abstract<any>)[];
 }
 
+export type DynamicAttributesCallback = (req: unknown, res: unknown) => Attributes;
+
 export type OpenTelemetryMetrics = {
   hostMetrics?: boolean;
   apiMetrics?: {
     enable?: boolean;
     defaultAttributes?: Attributes;
+    dynamicAttributes?: DynamicAttributesCallback;
     ignoreRoutes?: (string | RouteInfo)[];
     ignoreUndefinedRoutes?: boolean;
     prefix?: string;

--- a/src/middleware/api-metrics.middleware.ts
+++ b/src/middleware/api-metrics.middleware.ts
@@ -124,7 +124,9 @@ export class ApiMetricsMiddleware implements NestMiddleware {
         path = urlParser.parse(url).pathname;
       }
 
-      this.httpServerRequestCount.add(1, { method, path });
+      const dynamicAttributes = this.getDynamicAttributes(req, res);
+
+      this.httpServerRequestCount.add(1, { method, path, ...dynamicAttributes });
 
       const requestLength = parseInt(req.headers['content-length'], 10) || 0;
       const responseLength: number = parseInt(res.getHeader('Content-Length'), 10) || 0;
@@ -135,7 +137,7 @@ export class ApiMetricsMiddleware implements NestMiddleware {
         status,
         path,
         ...this.defaultAttributes,
-        ...this.getDynamicAttributes(req, res),
+        ...dynamicAttributes,
       };
 
       this.httpServerRequestSize.record(requestLength, attributes);


### PR DESCRIPTION
### Description

This PR adds the possibility to define dynamic attributes to server request and response metrics. Can be used with req and res params.

- [x] created e2e test

Fixes https://github.com/pragmaticivan/nestjs-otel/issues/123