### PR TITLE
chore: Node 22 deprecation warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.8.0",
-        "@opentelemetry/host-metrics": "^0.35.1",
+        "@opentelemetry/host-metrics": "^0.35.4",
         "response-time": "^2.3.2"
       },
       "devDependencies": {
@@ -1767,12 +1767,12 @@
       }
     },
     "node_modules/@opentelemetry/host-metrics": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/host-metrics/-/host-metrics-0.35.1.tgz",
-      "integrity": "sha512-d49/Un/pzqUSsGLeO8PvrX2bLxVAORcaoL3nxjJCzGikXA6gjWXxGOfT8D4qePlgnocozppWszefMHoRFS2MsA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/host-metrics/-/host-metrics-0.35.4.tgz",
+      "integrity": "sha512-3nPElbfYZ2oKNoMw2CkXkHxQryebqACcSgMbbKcn+GnGKp+h7MeOHyg21NmmTt9xgCvRHYiHNkWGkB4laP0oUw==",
       "dependencies": {
         "@opentelemetry/sdk-metrics": "^1.8.0",
-        "systeminformation": "^5.21.20"
+        "systeminformation": "5.22.9"
       },
       "engines": {
         "node": ">=14"
@@ -7268,9 +7268,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.22.0.tgz",
-      "integrity": "sha512-oAP80ymt8ssrAzjX8k3frbL7ys6AotqC35oikG6/SG15wBw+tG9nCk4oPaXIhEaAOAZ8XngxUv3ORq2IuR3r4Q==",
+      "version": "5.22.9",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.22.9.tgz",
+      "integrity": "sha512-qUWJhQ9JSBhdjzNUQywpvc0icxUAjMY3sZqUoS0GOtaJV9Ijq8s9zEP8Gaqmymn1dOefcICyPXK1L3kgKxlUpg==",
       "os": [
         "darwin",
         "linux",
@@ -9133,12 +9133,12 @@
       }
     },
     "@opentelemetry/host-metrics": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/host-metrics/-/host-metrics-0.35.1.tgz",
-      "integrity": "sha512-d49/Un/pzqUSsGLeO8PvrX2bLxVAORcaoL3nxjJCzGikXA6gjWXxGOfT8D4qePlgnocozppWszefMHoRFS2MsA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/host-metrics/-/host-metrics-0.35.4.tgz",
+      "integrity": "sha512-3nPElbfYZ2oKNoMw2CkXkHxQryebqACcSgMbbKcn+GnGKp+h7MeOHyg21NmmTt9xgCvRHYiHNkWGkB4laP0oUw==",
       "requires": {
         "@opentelemetry/sdk-metrics": "^1.8.0",
-        "systeminformation": "^5.21.20"
+        "systeminformation": "5.22.9"
       }
     },
     "@opentelemetry/propagator-b3": {
@@ -13245,9 +13245,9 @@
       "dev": true
     },
     "systeminformation": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.22.0.tgz",
-      "integrity": "sha512-oAP80ymt8ssrAzjX8k3frbL7ys6AotqC35oikG6/SG15wBw+tG9nCk4oPaXIhEaAOAZ8XngxUv3ORq2IuR3r4Q=="
+      "version": "5.22.9",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.22.9.tgz",
+      "integrity": "sha512-qUWJhQ9JSBhdjzNUQywpvc0icxUAjMY3sZqUoS0GOtaJV9Ijq8s9zEP8Gaqmymn1dOefcICyPXK1L3kgKxlUpg=="
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/pragmaticivan/nestjs-otel#readme",
   "dependencies": {
     "@opentelemetry/api": "^1.8.0",
-    "@opentelemetry/host-metrics": "^0.35.1",
+    "@opentelemetry/host-metrics": "^0.35.4",
     "response-time": "^2.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This version of host-metrics bumps the systeminformation version to fix the deprecation warning described [here](https://github.com/sebhildebrandt/systeminformation/issues/908)