### PR TITLE
fix: span decorator preserves original method name

### DIFF
--- a/src/tracing/decorators/span.spec.ts
+++ b/src/tracing/decorators/span.spec.ts
@@ -66,6 +66,11 @@ describe('Span', () => {
     expect(Reflect.getMetadata('some-metadata', instance.metadata)).toEqual(true);
   });
 
+  it('should preserve the original method name', () => {
+    const originalFunctionName = instance.singleSpan.name;
+    expect(originalFunctionName).toEqual('singleSpan');
+  });
+
   it('should set correct span', async () => {
     instance.singleSpan();
 

--- a/src/tracing/decorators/span.ts
+++ b/src/tracing/decorators/span.ts
@@ -44,8 +44,15 @@ export function Span(name?: string, options: SpanOptions = {}) {
       });
     };
 
-    propertyDescriptor.value = wrappedFunction;
+    // Wrap the original function in a proxy to ensure that the function name is preserved.
+    // This should also preserve parameters for OpenAPI and other libraries
+    // that rely on the function name as metadata key.
+    propertyDescriptor.value = new Proxy(originalFunction, {
+      apply: (_, thisArg, args: any[]) => {
+        return wrappedFunction.apply(thisArg, args);
+      },
+    });
 
-    copyMetadataFromFunctionToFunction(originalFunction, wrappedFunction);
+    copyMetadataFromFunctionToFunction(originalFunction, propertyDescriptor.value);
   };
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to this project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/pragmaticivan/nestjs-otel/blob/main/CONTRIBUTING.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
 
When using the `@Span` decorator, the original function's name was not preserved. This breaks tools that store metadata in an external store using the method name as a key. It also messes with logging, if the user wants to print the called functions's name.

Fixes #502
Fixes #503 

## Short description of the changes

Wrapping the decorated function in a Proxy preserves all attributes of the original function, except the "apply" trap. This ensures the name (and any other parameters, like `.length`) is kept.

Note: We still need to copy the metadata from the original function, because those are associated with the function instance, which is different.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added a test case to `span.spec.ts`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated (not needed)
