### PR TITLE
feat: span decorator has access to function params

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,14 @@ export class OtelConfigService implements OpenTelemetryOptionsFactory {
 
 ## Span Decorator
 
-If you need, you can define a custom Tracing Span for a method. It works async or sync. Span takes its name from the parameter; but by default, it is derived as `<class-name>.<method-name>`.
+If you need, you can define a custom Tracing Span for a method. It works async or sync.
+
+Span optionally takes one or both of the following parameters:
+  * `name` - explicit name of the span; if omitted, it is derived as `<class-name>.<method-name>`.
+  * `options` - `SpanOptions` to customize the span options.
+
+You can also supply a function as the `options` argument. It will be called with the decorated method's arguments, so you can dynamically customize the span options.
+
 
 ```ts
 import { Span } from 'nestjs-otel';
@@ -195,10 +202,27 @@ export class BooksService {
   async getBooksAgain() {
       return [`Harry Potter and the Philosopher's Stone`];
   }
-}
-```
 
-The second parameter (or first, if name is omitted) is `SpanOptions` from opentelemetry.
+  // explicitly set span options
+  @Span('getBook', { kind: SpanKind.SERVER })
+  async getBook(id: number) {
+    // ...
+  }
+
+  // options are set dynamically based on the id parameter
+  @Span('getBook', (id) => ({ attributes: { bookId: id } }))
+  async getBookAgain(id: number) {
+    // ...
+  }
+
+  // same as above, but span name is omitted and inferred automatically
+  @Span((id) => ({ attributes: { bookId: id } }))
+  async getBookOnceMore(id: number) {
+    // ...
+  }
+}
+
+```
 
 ## Tracing Service
 

--- a/src/tracing/decorators/span.spec.ts
+++ b/src/tracing/decorators/span.spec.ts
@@ -24,8 +24,14 @@ class TestSpan {
   @Span('foo', { kind: SpanKind.PRODUCER })
   fooProducerSpan() {}
 
+  @Span('bar', (a, b) => ({ attributes: { a, b } }))
+  argsInOptions(a: number, b: string) {}
+
   @Span({ kind: SpanKind.PRODUCER })
   implicitSpanNameWithOptions() {}
+
+  @Span((a, b) => ({ attributes: { a, b } }))
+  argsInOptionsWithImplicitName(a: number, b: string) {}
 
   @Span()
   error() {
@@ -101,6 +107,24 @@ describe('Span', () => {
     expect(spans).toHaveLength(1);
     expect(spans[0].name).toEqual('TestSpan.implicitSpanNameWithOptions');
     expect(spans[0].kind).toEqual(SpanKind.PRODUCER);
+  });
+
+  it('should set correct span options based on method params', async () => {
+    instance.argsInOptions(10, 'bar');
+
+    const spans = traceExporter.getFinishedSpans();
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].attributes).toEqual({ a: 10, b: 'bar' });
+  });
+
+  it('should set correct span options based on method params with implicit span name', async () => {
+    instance.argsInOptionsWithImplicitName(10, 'bar');
+
+    const spans = traceExporter.getFinishedSpans();
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].attributes).toEqual({ a: 10, b: 'bar' });
   });
 
   it('should set correct span even when calling other method with Span decorator', async () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to this project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/pragmaticivan/nestjs-otel/blob/main/CONTRIBUTING.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Ability to customize Span options based on method parameters

Fixes #470 

---

~Note: this PR is based on #537 so it should only be merged after that one. The relevant changes are in the last commit.~

## Short description of the changes

The options parameter now supports passing in a function that evaluates to SpanOptions based on the function parameters:

```
@Span('bar', (a, b) => ({ attributes: { a, b } }))
argsInOptions(a: number, b: string) {}
```


Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] added a test case to `span.spec.ts`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
