### PR TITLE
fix: preserve method and class name decorated with OtelXxxCounter

### DIFF
--- a/src/metrics/decorators/common.spec.ts
+++ b/src/metrics/decorators/common.spec.ts
@@ -34,4 +34,8 @@ describe('OtelMethodCounter', () => {
   it('should maintain reflect metadata', async () => {
     expect(Reflect.getMetadata('some-metadata', instance.method)).toEqual(true);
   });
+
+  it('should preserve the original method name', async () => {
+    expect(instance.method.name).toEqual('method');
+  });
 });

--- a/src/metrics/decorators/common.spec.ts
+++ b/src/metrics/decorators/common.spec.ts
@@ -22,6 +22,10 @@ describe('OtelInstanceCounter', () => {
   it('should maintain reflect metadata', async () => {
     expect(Reflect.getMetadata('some-metadata', instance.constructor)).toEqual(true);
   });
+
+  it('should preserve the original class name', async () => {
+    expect(instance.constructor.name).toEqual('TestClass');
+  });
 });
 
 describe('OtelMethodCounter', () => {

--- a/src/metrics/decorators/common.ts
+++ b/src/metrics/decorators/common.ts
@@ -56,7 +56,11 @@ export const OtelMethodCounter =
       // @ts-ignore
       return originalFunction.apply(this, args);
     };
-    descriptor.value = wrappedFunction;
+    descriptor.value = new Proxy(originalFunction, {
+      apply: (_, thisArg, args: any[]) => {
+        return wrappedFunction.apply(thisArg, args);
+      },
+    });
 
-    copyMetadataFromFunctionToFunction(originalFunction, wrappedFunction);
+    copyMetadataFromFunctionToFunction(originalFunction, descriptor.value);
   };

--- a/src/metrics/decorators/common.ts
+++ b/src/metrics/decorators/common.ts
@@ -25,6 +25,7 @@ export const OtelInstanceCounter =
         super(...args);
       }
     };
+    Object.defineProperty(wrappedClass, 'name', { value: originalClass.name });
 
     copyMetadataFromFunctionToFunction(originalClass, wrappedClass);
 


### PR DESCRIPTION
<!--
We appreciate your contribution to this project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/pragmaticivan/nestjs-otel/blob/main/CONTRIBUTING.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The same problem as #538 

## Short description of the changes

* Use Proxy to preserve decorated method name.
* Explicitly define name property on decorated class.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] added tests to `common.spec.ts`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated (not needed)
