### PR TITLE
Feature: add a `getGauge` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ You have the following decorators:
 - `@OtelCounter()`
 - `@OtelUpDownCounter()`
 - `@OtelHistogram()`
+- `@OtelGauge()`
 - `@OtelObservableGauge()`
 - `@OtelObservableCounter()`
 - `@OtelObservableUpDownCounter()`

--- a/src/metrics/decorators/param.ts
+++ b/src/metrics/decorators/param.ts
@@ -2,6 +2,7 @@ import { createParamDecorator } from '@nestjs/common';
 import { OtelMetricOptions } from '../../interfaces/metric-options.interface';
 import {
   getOrCreateCounter,
+  getOrCreateGauge,
   getOrCreateHistogram,
   getOrCreateObservableCounter,
   getOrCreateObservableGauge,
@@ -32,6 +33,7 @@ export const OtelUpDownCounter = createMetricParamDecorator(
   'OtelUpDownCounter',
   getOrCreateCounter
 );
+export const OtelGauge = createMetricParamDecorator('OtelGauge', getOrCreateGauge);
 
 export const OtelHistogram = createMetricParamDecorator('OtelHistogram', getOrCreateHistogram);
 

--- a/src/metrics/metric-data.ts
+++ b/src/metrics/metric-data.ts
@@ -1,4 +1,5 @@
 import {
+  Gauge,
   Counter,
   UpDownCounter,
   Histogram,
@@ -14,6 +15,7 @@ export type GenericMetric =
   | Counter
   | UpDownCounter
   | Histogram
+  | Gauge
   | ObservableGauge
   | ObservableCounter
   | ObservableUpDownCounter;
@@ -22,6 +24,7 @@ export enum MetricType {
   'Counter' = 'Counter',
   'UpDownCounter' = 'UpDownCounter',
   'Histogram' = 'Histogram',
+  'Gauge' = 'Gauge',
   'ObservableGauge' = 'ObservableGauge',
   'ObservableCounter' = 'ObservableCounter',
   'ObservableUpDownCounter' = 'ObservableUpDownCounter',
@@ -50,6 +53,10 @@ export function getOrCreateHistogram(name: string, options: OtelMetricOptions = 
 
 export function getOrCreateCounter(name: string, options: OtelMetricOptions = {}): Counter {
   return getOrCreate(name, options, MetricType.Counter) as Counter;
+}
+
+export function getOrCreateGauge(name: string, options: OtelMetricOptions = {}): Gauge {
+  return getOrCreate(name, options, MetricType.Gauge) as Gauge;
 }
 
 export function getOrCreateUpDownCounter(

--- a/src/metrics/metric.service.ts
+++ b/src/metrics/metric.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import {
   getOrCreateCounter,
   getOrCreateHistogram,
+  getOrCreateGauge,
   getOrCreateObservableCounter,
   getOrCreateObservableGauge,
   getOrCreateObservableUpDownCounter,
@@ -21,6 +22,10 @@ export class MetricService {
 
   getHistogram(name: string, options?: OtelMetricOptions) {
     return getOrCreateHistogram(name, options);
+  }
+
+  getGauge(name: string, options?: OtelMetricOptions) {
+    return getOrCreateGauge(name, options);
   }
 
   getObservableCounter(name: string, options?: OtelMetricOptions) {

--- a/tests/e2e/metrics/decorators/common.spec.ts
+++ b/tests/e2e/metrics/decorators/common.spec.ts
@@ -65,6 +65,18 @@ describe('Common Decorators', () => {
 
       expect(/# HELP example_counter_total An example counter/.test(text)).toBeTruthy();
       expect(/example_counter_total 1/.test(text)).toBeTruthy();
+
+      expect(/# HELP example_gauge An example gauge/.test(text)).toBeTruthy();
+      expect(/example_gauge 5/.test(text)).toBeTruthy();
+
+      expect(/# HELP example_up_down_total An example up-down counter/.test(text)).toBeTruthy();
+      expect(/example_up_down_total 2/.test(text)).toBeTruthy();
+
+      expect(/# HELP example_histogram An example histogram/.test(text)).toBeTruthy();
+      expect(/example_histogram_count 1/.test(text)).toBeTruthy();
+      expect(/example_histogram_sum 8/.test(text)).toBeTruthy();
+      expect(/example_histogram_bucket{le="5"} 0/.test(text)).toBeTruthy();
+      expect(/example_histogram_bucket{le="10"} 1/.test(text)).toBeTruthy();
     });
   });
 });

--- a/tests/e2e/metrics/metric.service.spec.ts
+++ b/tests/e2e/metrics/metric.service.spec.ts
@@ -317,4 +317,91 @@ describe('MetricService', () => {
       expect(data.has('test_prefix.test1')).toBeTruthy();
     });
   });
+
+  describe('getGauge', () => {
+    it('creates a new gauge on meterData on the first time method is called', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          OpenTelemetryModule.forRoot({
+            metrics: {
+              apiMetrics: {
+                enable: false,
+              },
+            },
+          }),
+        ],
+      }).compile();
+
+      app = moduleRef.createNestApplication();
+      await app.init();
+
+      metricService = moduleRef.get<MetricService>(MetricService);
+      // Starts empty
+      expect(meterData.size).toBe(0);
+
+      const gauge = metricService.getGauge('test1');
+      gauge.record(2);
+
+      // Has new key record
+      const data = meterData;
+      expect(data.has('test1')).toBeTruthy();
+    });
+
+    it('reuses an existing gauge on meterData when method is called twice', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          OpenTelemetryModule.forRoot({
+            metrics: {
+              apiMetrics: {
+                enable: false,
+              },
+            },
+          }),
+        ],
+      }).compile();
+
+      app = moduleRef.createNestApplication();
+      await app.init();
+
+      metricService = moduleRef.get<MetricService>(MetricService);
+
+      const counter = metricService.getGauge('test1', { description: 'test1 description' });
+      counter.record(1);
+
+      const existingCounter = metricService.getGauge('test1');
+
+      expect(meterData.has('test1')).toBeTruthy();
+      // TODO: The metric class does not expose current description
+      // @ts-ignore
+      expect(existingCounter._descriptor.description).toBe('test1 description');
+    });
+
+    it('uses prefix when provided', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          OpenTelemetryModule.forRoot({
+            metrics: {
+              apiMetrics: {
+                enable: false,
+              },
+            },
+          }),
+        ],
+      }).compile();
+
+      app = moduleRef.createNestApplication();
+      await app.init();
+
+      metricService = moduleRef.get<MetricService>(MetricService);
+      // Starts empty
+      expect(meterData.size).toBe(0);
+
+      const counter = metricService.getGauge('test1', { prefix: 'test_prefix' });
+      counter.record(1);
+
+      // Has new key record
+      const data = meterData;
+      expect(data.has('test_prefix.test1')).toBeTruthy();
+    });
+  });
 });

--- a/tests/fixture-app/app.controller.ts
+++ b/tests/fixture-app/app.controller.ts
@@ -1,7 +1,12 @@
 import { Get, Controller } from '@nestjs/common';
-import { Counter } from '@opentelemetry/api';
+import { Counter, Gauge, Histogram, UpDownCounter } from '@opentelemetry/api';
 import { OtelInstanceCounter, OtelMethodCounter } from '../../src/metrics/decorators/common';
-import { OtelCounter } from '../../src/metrics/decorators/param';
+import {
+  OtelCounter,
+  OtelGauge,
+  OtelHistogram,
+  OtelUpDownCounter,
+} from '../../src/metrics/decorators/param';
 
 @OtelInstanceCounter()
 @Controller('example')
@@ -13,8 +18,18 @@ export class AppController {
 
   @Get(':id')
   @OtelMethodCounter()
-  example(@OtelCounter('example_counter', { description: 'An example counter' }) counter: Counter) {
+  example(
+    @OtelCounter('example_counter', { description: 'An example counter' }) counter: Counter,
+    @OtelGauge('example_gauge', { description: 'An example gauge' }) gauge: Gauge,
+    @OtelUpDownCounter('example_up_down', { description: 'An example up-down counter' })
+    upDownCounter: UpDownCounter,
+    @OtelHistogram('example_histogram', { description: 'An example histogram' })
+    histogram: Histogram
+  ) {
     counter.add(1);
+    upDownCounter.add(2);
+    gauge.record(5);
+    histogram.record(8);
     return 'example';
   }
 }


### PR DESCRIPTION
Hi!

## Which problem is this PR solving?

There is currently no way to create a simple `Gauge` metric. Only the ObservableGauge is available.

The work around was to use the meter provider directly from the Otel API.
> metrics.getMeterProvider().getMeter(OTEL_METER_NAME)

## Description of the changes

This PR adds a `getGauge` method on the `MeterService` and a `@OtelGauge` decorator

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added a unit test for the getGauge method

Added a E2E test for the new Gauge decorator (And also added assertions for the other missing metrics (UpDownCounter, Histogram))

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
