### PR TITLE
fix: dont eagerly trigger on functions that return thennable objects

### DIFF
--- a/src/tracing/decorators/span.spec.ts
+++ b/src/tracing/decorators/span.spec.ts
@@ -85,6 +85,13 @@ class TestSpan {
   returnsFailingLazyThenable() {
     return makeFailingLazyThenable(new Error("lazy rejection"));
   }
+
+  @Span({
+    onResult: (_result) => ({ attributes: { count: _result.rows.length } }),
+  })
+  lazyThenableOnResult() {
+    return makeLazyThenable({ rows: [1, 2, 3] });
+  }
 }
 
 /**
@@ -309,6 +316,27 @@ describe("Span", () => {
     // Should have exception event
     expect(spans[0].events).toHaveLength(1);
     expect(spans[0].events[0].name).toBe("exception");
+  });
+
+  it("should call onResult with the thenable (not resolved value) for lazy thenables", () => {
+    // The decorator hands the lazy thenable to onResult untouched (it cannot
+    // know it is a deferred query). Accessing fields on the resolved shape
+    // (e.g. `.rows`) therefore throws synchronously, and the decorator records
+    // that as an exception on the span.
+    const returned = instance.lazyThenableOnResult();
+
+    // Caller still receives the untouched thenable.
+    expect(returned.triggered).toBe(false);
+
+    const spans = traceExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].status.code).toBe(SpanStatusCode.ERROR);
+    expect(spans[0].status.message).toMatch(
+      "Cannot read properties of undefined (reading 'length')"
+    );
+    expect(spans[0].events).toHaveLength(1);
+    expect(spans[0].events[0].name).toBe("exception");
+    expect(spans[0].events[0].attributes?.["exception.type"]).toBe("TypeError");
   });
 
   it("should not trigger a lazy thenable returned by the wrapped method", () => {

--- a/src/tracing/decorators/span.spec.ts
+++ b/src/tracing/decorators/span.spec.ts
@@ -68,12 +68,22 @@ class TestSpan {
     return "success";
   }
 
+  @Span()
+  async asyncError() {
+    throw new Error("async hello world");
+  }
+
   lastLazyThenable?: LazyThenable<string>;
 
   @Span()
   returnsLazyThenable() {
     this.lastLazyThenable = makeLazyThenable("lazy result");
     return this.lastLazyThenable;
+  }
+
+  @Span()
+  returnsFailingLazyThenable() {
+    return makeFailingLazyThenable(new Error("lazy rejection"));
   }
 }
 
@@ -91,17 +101,40 @@ type LazyThenable<T> = PromiseLike<T> & {
 function makeLazyThenable<T>(value: T): LazyThenable<T> {
   const thenable: LazyThenable<T> = {
     triggered: false,
+    // biome-ignore lint/suspicious/noThenProperty: <We are testing the behavior of the thenable>
     then(onFulfilled, onRejected) {
       thenable.triggered = true;
       try {
         const result = onFulfilled ? onFulfilled(value) : (value as never);
         return Promise.resolve(result);
       } catch (error) {
-        if (onRejected) return Promise.resolve(onRejected(error)) as never;
+        if (onRejected) {
+          return Promise.resolve(onRejected(error)) as never;
+        }
         return Promise.reject(error) as never;
       }
     },
     catch(onRejected) {
+      return thenable.then(undefined, onRejected);
+    },
+  };
+  return thenable;
+}
+
+function makeFailingLazyThenable(
+  error: Error
+): PromiseLike<never> & { triggered: boolean } {
+  const thenable = {
+    triggered: false,
+    // biome-ignore lint/suspicious/noThenProperty: <We are testing the behavior of the thenable>
+    then(_onFulfilled: any, onRejected?: any) {
+      thenable.triggered = true;
+      if (onRejected) {
+        return Promise.resolve(onRejected(error)) as never;
+      }
+      return Promise.reject(error) as never;
+    },
+    catch(onRejected?: any) {
       return thenable.then(undefined, onRejected);
     },
   };
@@ -287,5 +320,57 @@ describe("Span", () => {
     // caller intended to defer (or compose further) before awaiting.
     expect(instance.lastLazyThenable?.triggered).toBe(false);
     expect(returned).toBe(instance.lastLazyThenable);
+  });
+
+  it("should end the span synchronously before the caller awaits a lazy thenable", () => {
+    instance.returnsLazyThenable();
+
+    // The span closes as soon as the decorated method returns, before the
+    // caller subscribes to the thenable, because the decorator cannot know
+    // whether the caller will compose it further or await it at all.
+    const spans = traceExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("TestSpan.returnsLazyThenable");
+  });
+
+  it("should not record errors from a lazy thenable that rejects after the span has ended", async () => {
+    const returned = instance.returnsFailingLazyThenable();
+
+    // Span is already closed — no error recorded yet.
+    const spans = traceExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].status.code).toBe(SpanStatusCode.UNSET);
+    expect(spans[0].events).toHaveLength(0);
+
+    // Caller awaits the thenable now — it rejects — but the span is gone.
+    await expect(Promise.resolve(returned)).rejects.toThrow("lazy rejection");
+
+    // Known limitation: the rejection is invisible to the span.
+    expect(traceExporter.getFinishedSpans()[0].events).toHaveLength(0);
+  });
+
+  it("should still track results from async (real Promise) methods", async () => {
+    const result = await instance.asyncMethod();
+    expect(result).toBe("async success");
+
+    const spans = traceExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("TestSpan.asyncMethod");
+    expect(spans[0].status.code).toBe(SpanStatusCode.UNSET);
+    expect(spans[0].attributes).toEqual({ result: "async success" });
+  });
+
+  it("should still track errors thrown by async (real Promise) methods", async () => {
+    await expect(instance.asyncError()).rejects.toThrow("async hello world");
+
+    const spans = traceExporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("TestSpan.asyncError");
+    expect(spans[0].status).toEqual({
+      code: SpanStatusCode.ERROR,
+      message: "async hello world",
+    });
+    expect(spans[0].events).toHaveLength(1);
+    expect(spans[0].events[0].name).toBe("exception");
   });
 });

--- a/src/tracing/decorators/span.spec.ts
+++ b/src/tracing/decorators/span.spec.ts
@@ -67,6 +67,45 @@ class TestSpan {
   errorInOnResult() {
     return "success";
   }
+
+  lastLazyThenable?: LazyThenable<string>;
+
+  @Span()
+  returnsLazyThenable() {
+    this.lastLazyThenable = makeLazyThenable("lazy result");
+    return this.lastLazyThenable;
+  }
+}
+
+/**
+ * Builds a "lazy" thenable in the style of query builders such as Knex,
+ * Mongoose Query, or Drizzle: it only performs work when a consumer
+ * actually subscribes via `.then()`. The `triggered` flag flips true
+ * the moment `.then()` is invoked.
+ */
+type LazyThenable<T> = PromiseLike<T> & {
+  triggered: boolean;
+  catch: (onRejected?: (e: unknown) => unknown) => PromiseLike<unknown>;
+};
+
+function makeLazyThenable<T>(value: T): LazyThenable<T> {
+  const thenable: LazyThenable<T> = {
+    triggered: false,
+    then(onFulfilled, onRejected) {
+      thenable.triggered = true;
+      try {
+        const result = onFulfilled ? onFulfilled(value) : (value as never);
+        return Promise.resolve(result);
+      } catch (error) {
+        if (onRejected) return Promise.resolve(onRejected(error)) as never;
+        return Promise.reject(error) as never;
+      }
+    },
+    catch(onRejected) {
+      return thenable.then(undefined, onRejected);
+    },
+  };
+  return thenable;
 }
 
 describe("Span", () => {
@@ -237,5 +276,16 @@ describe("Span", () => {
     // Should have exception event
     expect(spans[0].events).toHaveLength(1);
     expect(spans[0].events[0].name).toBe("exception");
+  });
+
+  it("should not trigger a lazy thenable returned by the wrapped method", () => {
+    const returned = instance.returnsLazyThenable();
+
+    // The decorator must hand the lazy thenable back to the caller untouched.
+    // It must NOT subscribe via .then(), which would force-execute query
+    // builders such as Knex, Mongoose Query, or Drizzle queries that the
+    // caller intended to defer (or compose further) before awaiting.
+    expect(instance.lastLazyThenable?.triggered).toBe(false);
+    expect(returned).toBe(instance.lastLazyThenable);
   });
 });

--- a/src/tracing/decorators/span.ts
+++ b/src/tracing/decorators/span.ts
@@ -97,11 +97,7 @@ export function Span<T extends any[]>(
         try {
           const result = originalFunction.apply(this, args);
 
-          if (
-            result &&
-            typeof result.then === "function" &&
-            typeof result.catch === "function"
-          ) {
+          if (result instanceof Promise) {
             return result
               .then((res: any) => {
                 handleOnResult(span, onResult, res);


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves the problem described in this issue: https://github.com/pragmaticivan/nestjs-otel/issues/595

As annotated in the code, there are many libraries that are Promise-like that do not execute until `.then()` is called. Wrapping those functions with a `@Span` would cause them to be executed inadvertently.

Fixes # (issue)

## Short description of the changes

Instead of checking to see if `.then` and `.catch` are functions, we check if the object is an `instanceof Promise`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] TDD Approach with the tests added in the PR.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
