### PR TITLE
feat: add wide events support for tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ lerna-debug.log*
 !.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/mcp.json
+
+# AI
+graphify-out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`nestjs-otel` — NestJS module wrapping OpenTelemetry (`@opentelemetry/api`). Published library (`main: lib/index.js`). Provides tracing, metrics, and wide-events to NestJS apps. Node >= 22. NestJS 11 peer dep.
+
+The library does **not** start the OTEL SDK. Consumers create their own `NodeSDK` (`tracing.ts`) and call `otelSDK.start()` before `NestFactory.create`. This module reads the global tracer/meter providers the SDK registers (`trace.getTracer`, `metrics.getMeterProvider`).
+
+## Commands
+
+```bash
+npm run build         # tsc → lib/ (prebuild rimraf's lib first)
+npm run lint          # ultracite check (biome wrapper)
+npm run format        # ultracite fix (auto-fix lint)
+npm test              # unit + e2e
+npm run test:unit     # jest, *.spec.ts under src/
+npm run test:e2e      # jest tests/jest-e2e.json, --runInBand
+npm run test:coverage
+npm run test:watch
+```
+
+Run a single test: `npx jest src/wide-events/wide-event.service.spec.ts` (or `-t "<test name>"`). E2E single: `npx jest --config ./tests/jest-e2e.json tests/e2e/<file>.e2e-spec.ts`.
+
+Unit specs live next to source under `src/`. E2E specs in `tests/e2e/` run against `tests/fixture-app/` (a real NestJS app). Commits use Conventional Commits (commitlint + husky). `lint-staged` runs `ultracite fix` on staged files.
+
+## Architecture
+
+`OpenTelemetryModule.forRoot(options)` / `forRootAsync(options)` (`src/opentelemetry.module.ts`) are thin shells delegating to `OpenTelemetryCoreModule` (`src/opentelemetry-core.module.ts`). The core module is `@Global`, registers + exports `TraceService`, `MetricService`, `WideEventService`, `WideEventInterceptor`, and the `OPENTELEMETRY_MODULE_OPTIONS` token. `onApplicationBootstrap` is the only runtime side effect — it starts `HostMetrics` when `options.metrics.hostMetrics` is true. `forRootAsync` supports `useFactory` / `useClass` / `useExisting` via `OpenTelemetryOptionsFactory`.
+
+Three feature areas, each exported through `src/index.ts`:
+
+- **tracing** (`src/tracing/`): `TraceService` is a thin accessor over the global tracer. The real work is in decorators (`src/tracing/decorators/`): `@Span(name?, options?)` wraps a method in `startActiveSpan`, handles sync + Promise returns, records exceptions, supports an `onResult` callback to set attributes from the return value. `@Traceable` applies `@Span` to every method of a class. `@Baggage` / `@CurrentSpan` are param decorators. Decorators preserve the original function name/metadata via a `Proxy` + `copyMetadataFromFunctionToFunction` (`src/opentelemetry.utils.ts`) — critical so OpenAPI/Nest reflection still works.
+
+- **metrics** (`src/metrics/`): `MetricService` exposes `getCounter`/`getHistogram`/`getGauge`/observable variants, all delegating to `getOrCreate*` in `src/metrics/metric-data.ts`, which caches instruments by name in a module-level map (idempotent re-fetch). `@InjectMetric(name)` (`src/metrics/injector.ts`) injects a named instrument via a DI token from `getToken`. Class/method decorators in `src/metrics/decorators/` (`OtelInstanceCounter`, `OtelMethodCounter`, etc.) auto-instrument.
+
+- **wide-events** (`src/wide-events/`): one structured event (a wide span) per request. `WideEventInterceptor` opens a `WideEventBag` (a `Map`) stored on the active OTEL context under `WIDE_EVENT_CONTEXT_KEY`, then on `finalize` flushes all accumulated attributes onto the span that was active when the request entered. `WideEventService` (`set`/`setMany`/`increment`/`startTimer`) and the `@WideEventField` decorator mutate that bag via `getWideEventBag()` — all **no-ops outside an intercepted request**. The interceptor seeds `code.function.name` plus an optional `options.wideEvents.seed(executionContext)`, and records `error.type`/`error.message` on failure. Register globally with `APP_INTERCEPTOR` or per-controller with `@UseInterceptors`.
+
+Options/interfaces in `src/interfaces/`. Constants (token, tracer name `OTEL_TRACER_NAME`) in `src/opentelemetry.constants.ts`.
+
+## Conventions
+
+- Lint is `ultracite` (extends biome). Config in `biome.jsonc` already disables `noExplicitAny`, `useAwait`, barrel-file warnings — `any` is used freely in decorator code by design. Run `npm run format` before committing.
+- Public API symbols are tagged `@publicApi`; internal ones `@internal`. Keep new exports wired through `src/index.ts`.
+- Decorators must not break function identity — when adding/altering a method decorator, preserve name + metadata as the existing ones do.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/README.md
+++ b/README.md
@@ -306,6 +306,125 @@ export class BookService {
 }
 ```
 
+## Wide Events
+
+Wide events (also known as canonical log lines) emit one context-rich event per request, with attributes accumulated across the whole request lifecycle. See [A Practitioner's Guide to Wide Events](https://jeremymorrell.dev/blog/a-practitioners-guide-to-wide-events/) for the pattern.
+
+This library implements the pattern on top of OpenTelemetry: the `WideEventInterceptor` opens an attribute bag per request and, when the request finishes, flushes everything onto the span that was active when the request entered the interceptor (usually the root HTTP span created by your instrumentation). The `WideEventService` lets any provider enrich that bag from anywhere in the request's async call chain — no request-scoped injection needed.
+
+1. Register the interceptor globally:
+
+```ts
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { OpenTelemetryModule, WideEventInterceptor } from 'nestjs-otel';
+
+@Module({
+  imports: [OpenTelemetryModule.forRoot()],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: WideEventInterceptor,
+    },
+  ],
+})
+export class AppModule {}
+```
+
+The example above opens a wide event for **every** request in the application. To limit wide events to specific controllers instead, skip the `APP_INTERCEPTOR` provider and apply the interceptor directly with `@UseInterceptors`:
+
+```ts
+import { Controller, Get, UseInterceptors } from '@nestjs/common';
+import { WideEventInterceptor } from 'nestjs-otel';
+
+@Controller('checkout')
+@UseInterceptors(WideEventInterceptor)
+export class CheckoutController {
+  // every route in this controller now emits a wide event
+}
+```
+
+2. Enrich the event from anywhere in the request:
+
+```ts
+import { WideEventService } from 'nestjs-otel';
+
+@Injectable()
+export class CheckoutService {
+  constructor(private readonly wideEvent: WideEventService) {}
+
+  async checkout(cart: Cart) {
+    this.wideEvent.setMany({
+      'user.id': cart.userId,
+      'cart.items': cart.items.length,
+      'cart.total': cart.total,
+    });
+
+    const stopTimer = this.wideEvent.startTimer('payment.duration_ms');
+    await this.paymentGateway.charge(cart);
+    stopTimer();
+
+    this.wideEvent.increment('db.queries');
+  }
+}
+```
+
+All accumulated attributes land on the root span as a single wide event:
+
+```
+http_request
+├── code.function.name: CheckoutController.checkout
+├── user.id: u-123
+├── cart.items: 3
+├── cart.total: 42.5
+├── payment.duration_ms: 132.7
+├── db.queries: 1
+├── error.type: PaymentDeclinedError   (set automatically on errors)
+└── error.message: card declined       (set automatically on errors)
+```
+
+Notes:
+
+- The interceptor seeds `code.function.name` (`<Controller>.<handler>`) automatically and records `error.type`/`error.message` when the handler throws.
+- `WideEventService` methods are safe no-ops outside a request handled by the interceptor.
+- An async-context-aware context manager is required (the default with `NodeSDK` / `AsyncLocalStorageContextManager`), same as for tracing in general.
+
+### Seeding baseline attributes
+
+Use the `seed` option to populate baseline attributes on every request (e.g. ids derived from the authenticated request). It runs after guards, so `req.user` is available. A throwing seed never breaks the request — the error is recorded under `wide_event.seed.error`.
+
+```ts
+OpenTelemetryModule.forRoot({
+  wideEvents: {
+    seed: (ctx) => {
+      const req = ctx.switchToHttp().getRequest();
+      return {
+        'app.version': process.env.BUILD_SHA,
+        'user.id': req.user?.id,
+      };
+    },
+  },
+});
+```
+
+Static values (version, region, ...) are often better modeled as OpenTelemetry [Resource](https://opentelemetry.io/docs/specs/otel/resource/sdk/) attributes; reserve `seed` for per-request derivations.
+
+### `@WideEventField` decorator
+
+Capture a method's return value (resolved value for async methods) onto the current wide event without calling the service manually. Works on any provider method that runs within the request's async context. A failing projection or a non-attribute value is silently skipped.
+
+```ts
+import { WideEventField } from 'nestjs-otel';
+
+@Injectable()
+export class BooksService {
+  // records `books.count` = result.length
+  @WideEventField('books.count', (books: string[]) => books.length)
+  async getBooks() {
+    return ['Book 1', 'Book 2'];
+  }
+}
+```
+
 ## Metric Service
 
 [OpenTelemetry Metrics](https://www.npmjs.com/package/@opentelemetry/api) allow a user to collect data and export it to metrics backend like Prometheus.

--- a/README.md
+++ b/README.md
@@ -310,7 +310,9 @@ export class BookService {
 
 Wide events (also known as canonical log lines) emit one context-rich event per request, with attributes accumulated across the whole request lifecycle. See [A Practitioner's Guide to Wide Events](https://jeremymorrell.dev/blog/a-practitioners-guide-to-wide-events/) for the pattern.
 
-This library implements the pattern on top of OpenTelemetry: the `WideEventInterceptor` opens an attribute bag per request and, when the request finishes, flushes everything onto the span that was active when the request entered the interceptor (usually the root HTTP span created by your instrumentation). The `WideEventService` lets any provider enrich that bag from anywhere in the request's async call chain — no request-scoped injection needed.
+This library implements the pattern on top of OpenTelemetry: the `WideEventInterceptor` opens an attribute bag per request and, when the request finishes, flushes everything onto a single span — marking it with `nestjs_otel.wide_event = true` so you can filter wide-event spans in your backend. The `WideEventService` lets any provider enrich that bag from anywhere in the request's async call chain — no request-scoped injection needed.
+
+By default the attributes land on the best-available recording span at flush time (the HTTP root on Express / plain Fastify, or the active handler span when an instrumentation such as `@opentelemetry/instrumentation-nestjs-core` or `@fastify/otel` nests a span per request phase). To guarantee they land on the **trace root span** regardless of instrumentation nesting, register the [`WideEventSpanProcessor`](#targeting-the-root-span-wideeventspanprocessor).
 
 1. Register the interceptor globally:
 
@@ -368,10 +370,11 @@ export class CheckoutService {
 }
 ```
 
-All accumulated attributes land on the root span as a single wide event:
+All accumulated attributes land on a single span as one wide event:
 
 ```
-http_request
+GET /checkout
+├── nestjs_otel.wide_event: true
 ├── code.function.name: CheckoutController.checkout
 ├── user.id: u-123
 ├── cart.items: 3
@@ -384,7 +387,8 @@ http_request
 
 Notes:
 
-- The interceptor seeds `code.function.name` (`<Controller>.<handler>`) automatically and records `error.type`/`error.message` when the handler throws.
+- The flushed span is marked `nestjs_otel.wide_event = true`. This marker is set last, so a handler-provided field can never overwrite it.
+- The interceptor seeds `code.function.name` (`<Controller>.<handler>`) automatically and records `error.type`/`error.message` (plus `error.stack` when present) when the handler throws.
 - `WideEventService` methods are safe no-ops outside a request handled by the interceptor.
 - An async-context-aware context manager is required (the default with `NodeSDK` / `AsyncLocalStorageContextManager`), same as for tracing in general.
 
@@ -424,6 +428,28 @@ export class BooksService {
   }
 }
 ```
+
+### Targeting the root span (`WideEventSpanProcessor`)
+
+Instrumentations like `@opentelemetry/instrumentation-nestjs-core` and `@fastify/otel` wrap each request phase (middleware, guard, handler) in its own span. As a result, the span active when the interceptor runs is a nested child, not the trace root — so by default the wide event lands on that child span (e.g. `AppController.handler`) rather than on the root `GET /route`.
+
+Register the `WideEventSpanProcessor` on your `NodeSDK` to make the interceptor flush onto the **local-root span** (the span with no in-process parent — normally the HTTP server span) instead:
+
+```ts
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { WideEventSpanProcessor } from 'nestjs-otel';
+
+export const otelSDK = new NodeSDK({
+  spanProcessors: [
+    new WideEventSpanProcessor(),
+    new BatchSpanProcessor(traceExporter),
+  ],
+  // ...instrumentations, contextManager, etc.
+});
+```
+
+The processor only tracks which span is the local root per trace; it never exports spans, so keep your existing exporting processor in the list. It is optional — without it, wide events still flush onto the best-available recording span (see above), just not necessarily the trace root.
 
 ## Metric Service
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestjs-otel",
-  "version": "8.0.3",
+  "version": "8.0.4-alpha.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nestjs-otel",
-      "version": "8.0.3",
+      "version": "8.0.4-alpha.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,8 @@
       },
       "peerDependencies": {
         "@nestjs/common": ">= 11 < 12",
-        "@nestjs/core": ">= 11 < 12"
+        "@nestjs/core": ">= 11 < 12",
+        "rxjs": "^7.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -78,6 +79,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1870,6 +1872,7 @@
       "integrity": "sha512-zDntUTReRbAThIfSp3dQZ9kKqI+LjgLp5YZN5c1bgNRDuoeLySAoZg46Bg1a+uV8TMgIRziHocglKGNzr6l+bQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.1.0",
         "iterare": "1.2.1",
@@ -1903,6 +1906,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -1944,6 +1948,7 @@
       "integrity": "sha512-GVd3+0lO0mJq2m1kl9hDDnVrX3Nd4oH3oDfklz0pZEVEVS0KVSp63ufHq2Lu9cyPdSBuelJr9iPm2QQ1yX+Kmw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
@@ -2059,6 +2064,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2307,6 +2313,7 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": ">=5.7.2"
       }
@@ -2484,6 +2491,7 @@
       "integrity": "sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3272,6 +3280,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -3786,6 +3795,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5325,6 +5335,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7368,7 +7379,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -7562,6 +7574,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -8556,6 +8569,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9057,6 +9071,7 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-otel",
-  "version": "8.0.3",
+  "version": "8.0.4-alpha.8",
   "description": "NestJS OpenTelemetry Library",
   "main": "lib/index.js",
   "typings": "lib/index",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   },
   "peerDependencies": {
     "@nestjs/common": ">= 11 < 12",
-    "@nestjs/core": ">= 11 < 12"
+    "@nestjs/core": ">= 11 < 12",
+    "rxjs": "^7.1.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,5 +11,7 @@ export * from "./tracing/decorators/traceable";
 export * from "./tracing/trace.service";
 export * from "./wide-events/wide-event.context";
 export * from "./wide-events/wide-event.interceptor";
+export * from "./wide-events/wide-event.middleware";
 export * from "./wide-events/wide-event.service";
+export * from "./wide-events/wide-event.span-processor";
 export * from "./wide-events/wide-event-field.decorator";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,7 @@ export * from "./tracing/decorators/current-span";
 export * from "./tracing/decorators/span";
 export * from "./tracing/decorators/traceable";
 export * from "./tracing/trace.service";
+export * from "./wide-events/wide-event.context";
+export * from "./wide-events/wide-event.interceptor";
+export * from "./wide-events/wide-event.service";
+export * from "./wide-events/wide-event-field.decorator";

--- a/src/interfaces/opentelemetry-options.interface.ts
+++ b/src/interfaces/opentelemetry-options.interface.ts
@@ -1,17 +1,27 @@
-import type { Abstract, ModuleMetadata, Type } from "@nestjs/common";
+import type {
+  Abstract,
+  ExecutionContext,
+  ModuleMetadata,
+  Type,
+} from "@nestjs/common";
+import type { Attributes } from "@opentelemetry/api";
 
-export type OpenTelemetryModuleOptions = {
+export interface OpenTelemetryModuleOptions {
   /**
    * OpenTelemetry Metrics Setup
    */
   metrics?: OpenTelemetryMetrics;
-};
+  /**
+   * Wide Events Setup, used by the WideEventInterceptor
+   */
+  wideEvents?: OpenTelemetryWideEvents;
+}
 
-export type OpenTelemetryOptionsFactory = {
+export interface OpenTelemetryOptionsFactory {
   createOpenTelemetryOptions():
     | Promise<OpenTelemetryModuleOptions>
     | OpenTelemetryModuleOptions;
-};
+}
 
 /**
  * The options for the asynchronous OpenTelemetry module creation
@@ -44,6 +54,14 @@ export interface OpenTelemetryModuleAsyncOptions
   inject?: (string | symbol | Function | Type<any> | Abstract<any>)[];
 }
 
-export type OpenTelemetryMetrics = {
+export interface OpenTelemetryMetrics {
   hostMetrics?: boolean;
-};
+}
+
+export interface OpenTelemetryWideEvents {
+  /**
+   * Called at the start of each request to seed baseline attributes
+   * (e.g. user/tenant ids derived from the request).
+   */
+  seed?: (context: ExecutionContext) => Attributes;
+}

--- a/src/opentelemetry-core.module.ts
+++ b/src/opentelemetry-core.module.ts
@@ -3,7 +3,9 @@ import {
   DynamicModule,
   Global,
   Inject,
+  MiddlewareConsumer,
   Module,
+  NestModule,
   OnApplicationBootstrap,
   Provider,
   Type,
@@ -20,6 +22,7 @@ import { MetricService } from "./metrics/metric.service";
 import { OPENTELEMETRY_MODULE_OPTIONS } from "./opentelemetry.constants";
 import { TraceService } from "./tracing/trace.service";
 import { WideEventInterceptor } from "./wide-events/wide-event.interceptor";
+import { WideEventMiddleware } from "./wide-events/wide-event.middleware";
 import { WideEventService } from "./wide-events/wide-event.service";
 
 /**
@@ -30,7 +33,9 @@ import { WideEventService } from "./wide-events/wide-event.service";
  */
 @Global()
 @Module({})
-export class OpenTelemetryCoreModule implements OnApplicationBootstrap {
+export class OpenTelemetryCoreModule
+  implements OnApplicationBootstrap, NestModule
+{
   constructor(
     @Inject(OPENTELEMETRY_MODULE_OPTIONS)
     private readonly options: OpenTelemetryModuleOptions = {}
@@ -55,6 +60,7 @@ export class OpenTelemetryCoreModule implements OnApplicationBootstrap {
         MetricService,
         WideEventService,
         WideEventInterceptor,
+        WideEventMiddleware,
       ],
       exports: [
         OPENTELEMETRY_MODULE_OPTIONS,
@@ -62,6 +68,7 @@ export class OpenTelemetryCoreModule implements OnApplicationBootstrap {
         MetricService,
         WideEventService,
         WideEventInterceptor,
+        WideEventMiddleware,
       ],
     };
   }
@@ -83,6 +90,7 @@ export class OpenTelemetryCoreModule implements OnApplicationBootstrap {
         MetricService,
         WideEventService,
         WideEventInterceptor,
+        WideEventMiddleware,
       ],
       exports: [
         OPENTELEMETRY_MODULE_OPTIONS,
@@ -90,8 +98,13 @@ export class OpenTelemetryCoreModule implements OnApplicationBootstrap {
         MetricService,
         WideEventService,
         WideEventInterceptor,
+        WideEventMiddleware,
       ],
     };
+  }
+
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(WideEventMiddleware).forRoutes("*");
   }
 
   async onApplicationBootstrap() {

--- a/src/opentelemetry-core.module.ts
+++ b/src/opentelemetry-core.module.ts
@@ -19,6 +19,8 @@ import {
 import { MetricService } from "./metrics/metric.service";
 import { OPENTELEMETRY_MODULE_OPTIONS } from "./opentelemetry.constants";
 import { TraceService } from "./tracing/trace.service";
+import { WideEventInterceptor } from "./wide-events/wide-event.interceptor";
+import { WideEventService } from "./wide-events/wide-event.service";
 
 /**
  * The internal OpenTelemetry Module which handles the integration
@@ -47,8 +49,20 @@ export class OpenTelemetryCoreModule implements OnApplicationBootstrap {
 
     return {
       module: OpenTelemetryCoreModule,
-      providers: [openTelemetryModuleOptions, TraceService, MetricService],
-      exports: [TraceService, MetricService],
+      providers: [
+        openTelemetryModuleOptions,
+        TraceService,
+        MetricService,
+        WideEventService,
+        WideEventInterceptor,
+      ],
+      exports: [
+        OPENTELEMETRY_MODULE_OPTIONS,
+        TraceService,
+        MetricService,
+        WideEventService,
+        WideEventInterceptor,
+      ],
     };
   }
 
@@ -63,8 +77,20 @@ export class OpenTelemetryCoreModule implements OnApplicationBootstrap {
     return {
       module: OpenTelemetryCoreModule,
       imports: [...(options.imports || [])],
-      providers: [...asyncProviders, TraceService, MetricService],
-      exports: [TraceService, MetricService],
+      providers: [
+        ...asyncProviders,
+        TraceService,
+        MetricService,
+        WideEventService,
+        WideEventInterceptor,
+      ],
+      exports: [
+        OPENTELEMETRY_MODULE_OPTIONS,
+        TraceService,
+        MetricService,
+        WideEventService,
+        WideEventInterceptor,
+      ],
     };
   }
 

--- a/src/wide-events/wide-event-field.decorator.spec.ts
+++ b/src/wide-events/wide-event-field.decorator.spec.ts
@@ -43,6 +43,11 @@ class TestService {
   metadata() {
     return 1;
   }
+
+  @WideEventField("items")
+  createInvalidArray() {
+    return [{ id: 1 }];
+  }
 }
 
 describe("WideEventField", () => {
@@ -100,6 +105,13 @@ describe("WideEventField", () => {
 
     expect(result).toEqual({ total: 42.5 });
     expect(bag.has("order")).toBe(false);
+  });
+
+  it("should skip arrays containing non-primitive elements", () => {
+    const result = withBag(() => instance.createInvalidArray());
+
+    expect(result).toEqual([{ id: 1 }]);
+    expect(bag.has("items")).toBe(false);
   });
 
   it("should be a no-op outside a wide event request", () => {

--- a/src/wide-events/wide-event-field.decorator.spec.ts
+++ b/src/wide-events/wide-event-field.decorator.spec.ts
@@ -1,0 +1,119 @@
+import "reflect-metadata";
+import { SetMetadata } from "@nestjs/common";
+import { context } from "@opentelemetry/api";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import {
+  WIDE_EVENT_CONTEXT_KEY,
+  type WideEventBag,
+} from "./wide-event.context";
+import { WideEventField } from "./wide-event-field.decorator";
+
+const TestDecoratorThatSetsMetadata = () => SetMetadata("some-metadata", true);
+
+class TestService {
+  @WideEventField("books.count")
+  countBooks() {
+    return 3;
+  }
+
+  @WideEventField("books.count")
+  async countBooksAsync() {
+    return 5;
+  }
+
+  @WideEventField("order.total", (order: { total: number }) => order.total)
+  createOrder() {
+    return { total: 42.5 };
+  }
+
+  @WideEventField("order.total", () => {
+    throw new Error("pick failed");
+  })
+  createOrderWithFailingPick() {
+    return { total: 42.5 };
+  }
+
+  @WideEventField("order")
+  createObjectWithoutPick() {
+    return { total: 42.5 };
+  }
+
+  @WideEventField("books.count")
+  @TestDecoratorThatSetsMetadata()
+  metadata() {
+    return 1;
+  }
+}
+
+describe("WideEventField", () => {
+  let instance: TestService;
+  let bag: WideEventBag;
+  let provider: NodeTracerProvider;
+
+  const withBag = <T>(fn: () => T): T =>
+    context.with(context.active().setValue(WIDE_EVENT_CONTEXT_KEY, bag), fn);
+
+  beforeAll(() => {
+    provider = new NodeTracerProvider();
+    provider.register();
+  });
+
+  afterAll(async () => {
+    await provider.shutdown();
+  });
+
+  beforeEach(() => {
+    instance = new TestService();
+    bag = new Map();
+  });
+
+  it("should record the return value of a sync method", () => {
+    const result = withBag(() => instance.countBooks());
+
+    expect(result).toBe(3);
+    expect(bag.get("books.count")).toBe(3);
+  });
+
+  it("should record the resolved value of an async method", async () => {
+    const result = await withBag(() => instance.countBooksAsync());
+
+    expect(result).toBe(5);
+    expect(bag.get("books.count")).toBe(5);
+  });
+
+  it("should record the picked value", () => {
+    const result = withBag(() => instance.createOrder());
+
+    expect(result).toEqual({ total: 42.5 });
+    expect(bag.get("order.total")).toBe(42.5);
+  });
+
+  it("should not break the method when pick throws", () => {
+    const result = withBag(() => instance.createOrderWithFailingPick());
+
+    expect(result).toEqual({ total: 42.5 });
+    expect(bag.size).toBe(0);
+  });
+
+  it("should skip values that are not valid attribute values", () => {
+    const result = withBag(() => instance.createObjectWithoutPick());
+
+    expect(result).toEqual({ total: 42.5 });
+    expect(bag.has("order")).toBe(false);
+  });
+
+  it("should be a no-op outside a wide event request", () => {
+    const result = instance.countBooks();
+
+    expect(result).toBe(3);
+    expect(bag.size).toBe(0);
+  });
+
+  it("should preserve the original method name", () => {
+    expect(instance.countBooks.name).toBe("countBooks");
+  });
+
+  it("should maintain reflect metadata", () => {
+    expect(Reflect.getMetadata("some-metadata", instance.metadata)).toBe(true);
+  });
+});

--- a/src/wide-events/wide-event-field.decorator.ts
+++ b/src/wide-events/wide-event-field.decorator.ts
@@ -1,0 +1,85 @@
+import type { AttributeValue } from "@opentelemetry/api";
+import { copyMetadataFromFunctionToFunction } from "../opentelemetry.utils";
+import { getWideEventBag } from "./wide-event.context";
+
+const isAttributeValue = (value: unknown): value is AttributeValue =>
+  typeof value === "string" ||
+  typeof value === "number" ||
+  typeof value === "boolean" ||
+  Array.isArray(value);
+
+const record = (
+  key: string,
+  pick: ((result: any) => AttributeValue) | undefined,
+  result: unknown
+): void => {
+  const bag = getWideEventBag();
+  if (!bag) {
+    return;
+  }
+  try {
+    const value = pick ? pick(result) : result;
+    if (isAttributeValue(value)) {
+      bag.set(key, value);
+    }
+  } catch {
+    // a failing pick must never break the decorated method
+  }
+};
+
+/**
+ * Captures the decorated method's return value (resolved value for async
+ * methods) as an attribute on the current wide event.
+ *
+ * No-op when called outside a request handled by the WideEventInterceptor,
+ * when `pick` throws, or when the value is not a valid attribute value.
+ *
+ * @param key The wide event attribute key.
+ * @param pick Optional projection of the return value to an attribute value.
+ *
+ * @publicApi
+ */
+export function WideEventField<T = any>(
+  key: string,
+  pick?: (result: T) => AttributeValue
+) {
+  return (
+    _target: any,
+    propertyKey: PropertyKey,
+    propertyDescriptor: TypedPropertyDescriptor<(...args: any[]) => any>
+  ) => {
+    const originalFunction = propertyDescriptor.value;
+
+    if (typeof originalFunction !== "function") {
+      throw new Error(
+        `The @WideEventField decorator can be only used on functions, but ${propertyKey.toString()} is not a function.`
+      );
+    }
+
+    const wrappedFunction = function WideEventFieldWrapper(
+      this: any,
+      ...args: any[]
+    ) {
+      const result = originalFunction.apply(this, args);
+
+      if (result instanceof Promise) {
+        return result.then((resolved: unknown) => {
+          record(key, pick, resolved);
+          return resolved;
+        });
+      }
+
+      record(key, pick, result);
+      return result;
+    };
+
+    propertyDescriptor.value = new Proxy(originalFunction, {
+      apply: (_, thisArg, args: any[]) => wrappedFunction.apply(thisArg, args),
+    });
+
+    copyMetadataFromFunctionToFunction(
+      originalFunction,
+      propertyDescriptor.value
+    );
+  };
+}

--- a/src/wide-events/wide-event-field.decorator.ts
+++ b/src/wide-events/wide-event-field.decorator.ts
@@ -2,11 +2,27 @@ import type { AttributeValue } from "@opentelemetry/api";
 import { copyMetadataFromFunctionToFunction } from "../opentelemetry.utils";
 import { getWideEventBag } from "./wide-event.context";
 
-const isAttributeValue = (value: unknown): value is AttributeValue =>
-  typeof value === "string" ||
-  typeof value === "number" ||
-  typeof value === "boolean" ||
-  Array.isArray(value);
+const isAttributeValue = (value: unknown): value is AttributeValue => {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return true;
+  }
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  let elementType: string | undefined;
+  for (const el of value) {
+    if (el == null) continue;
+    const t = typeof el;
+    if (t !== "string" && t !== "number" && t !== "boolean") return false;
+    if (elementType && t !== elementType) return false;
+    elementType = t;
+  }
+  return true;
+};
 
 const record = (
   key: string,

--- a/src/wide-events/wide-event.context.ts
+++ b/src/wide-events/wide-event.context.ts
@@ -1,0 +1,17 @@
+import {
+  type AttributeValue,
+  context,
+  createContextKey,
+} from "@opentelemetry/api";
+
+export const WIDE_EVENT_CONTEXT_KEY = createContextKey(
+  "nestjs-otel.wide-event"
+);
+
+export type WideEventBag = Map<string, AttributeValue>;
+
+export function getWideEventBag(): WideEventBag | undefined {
+  return context.active().getValue(WIDE_EVENT_CONTEXT_KEY) as
+    | WideEventBag
+    | undefined;
+}

--- a/src/wide-events/wide-event.context.ts
+++ b/src/wide-events/wide-event.context.ts
@@ -8,6 +8,8 @@ export const WIDE_EVENT_CONTEXT_KEY = createContextKey(
   "nestjs-otel.wide-event"
 );
 
+export const WIDE_EVENT_ROOT_SPAN = Symbol("nestjs-otel.wide-event.root-span");
+
 export type WideEventBag = Map<string, AttributeValue>;
 
 export function getWideEventBag(): WideEventBag | undefined {

--- a/src/wide-events/wide-event.interceptor.spec.ts
+++ b/src/wide-events/wide-event.interceptor.spec.ts
@@ -1,11 +1,11 @@
 import type { CallHandler, ExecutionContext } from "@nestjs/common";
-import { context, trace } from "@opentelemetry/api";
+import { context, SpanStatusCode, trace } from "@opentelemetry/api";
 import {
   InMemorySpanExporter,
   NodeTracerProvider,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-node";
-import { defer, lastValueFrom, of, throwError } from "rxjs";
+import { defer, lastValueFrom, Observable, of, throwError } from "rxjs";
 import type { OpenTelemetryModuleOptions } from "../interfaces";
 import { WideEventInterceptor } from "./wide-event.interceptor";
 import { WideEventService } from "./wide-event.service";
@@ -98,13 +98,30 @@ describe("WideEventInterceptor", () => {
   });
 
   it("should record error attributes when the handler throws", async () => {
+    const error = new Error("boom");
+
     await expect(
-      interceptWithRootSpan(() => throwError(() => new Error("boom")))
+      interceptWithRootSpan(() => throwError(() => error))
     ).rejects.toThrow("boom");
 
+    // #then
     const [span] = traceExporter.getFinishedSpans();
     expect(span.attributes["error.type"]).toBe("Error");
     expect(span.attributes["error.message"]).toBe("boom");
+    expect(span.attributes["error.stack"]).toBe(error.stack);
+  });
+
+  it("should not record error.stack when the error has no stack", async () => {
+    const error = new Error("no stack");
+    error.stack = undefined;
+
+    await expect(
+      interceptWithRootSpan(() => throwError(() => error))
+    ).rejects.toThrow("no stack");
+
+    // #then
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.attributes["error.stack"]).toBeUndefined();
   });
 
   it("should seed attributes from the configured seed callback", async () => {
@@ -130,6 +147,60 @@ describe("WideEventInterceptor", () => {
     expect(result).toBe("ok");
     const [span] = traceExporter.getFinishedSpans();
     expect(span.attributes["wide_event.seed.error"]).toBe("seed boom");
+  });
+
+  it("should set span status to ERROR when the handler throws", async () => {
+    await expect(
+      interceptWithRootSpan(() => throwError(() => new Error("fail")))
+    ).rejects.toThrow("fail");
+
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.status.code).toBe(SpanStatusCode.ERROR);
+  });
+
+  it("should handle exotic errors with null constructor without replacing the original error", async () => {
+    const exoticError = Object.create(Error.prototype);
+    exoticError.message = "exotic";
+    Object.defineProperty(exoticError, "constructor", { value: null });
+
+    await expect(
+      interceptWithRootSpan(() => throwError(() => exoticError))
+    ).rejects.toBe(exoticError);
+
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.attributes["error.type"]).toBe("Error");
+    expect(span.attributes["error.message"]).toBe("exotic");
+  });
+
+  it("should not flush attributes when the observable is unsubscribed before completion", async () => {
+    const span = trace.getTracer("test").startSpan("http_request");
+    const neverCompletes = new Observable((s) => {
+      s.next("partial");
+    });
+
+    const obs$ = context.with(trace.setSpan(context.active(), span), () =>
+      interceptor.intercept(
+        executionContext,
+        callHandler(() => neverCompletes)
+      )
+    );
+
+    const sub = obs$.subscribe();
+    sub.unsubscribe();
+    span.end();
+
+    const [finished] = traceExporter.getFinishedSpans();
+    expect(finished.attributes["code.function.name"]).toBeUndefined();
+  });
+
+  it("should not throw and should produce no seed error when seed returns null", async () => {
+    const result = await interceptWithRootSpan(() => of("ok"), {
+      wideEvents: { seed: () => null as any },
+    });
+
+    expect(result).toBe("ok");
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.attributes["wide_event.seed.error"]).toBeUndefined();
   });
 
   it("should propagate the handler result untouched when no span is active", async () => {

--- a/src/wide-events/wide-event.interceptor.spec.ts
+++ b/src/wide-events/wide-event.interceptor.spec.ts
@@ -1,0 +1,146 @@
+import type { CallHandler, ExecutionContext } from "@nestjs/common";
+import { context, trace } from "@opentelemetry/api";
+import {
+  InMemorySpanExporter,
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import { defer, lastValueFrom, of, throwError } from "rxjs";
+import type { OpenTelemetryModuleOptions } from "../interfaces";
+import { WideEventInterceptor } from "./wide-event.interceptor";
+import { WideEventService } from "./wide-event.service";
+
+class CatsController {
+  findAll() {}
+}
+
+const executionContext = {
+  getClass: () => CatsController,
+  getHandler: () => CatsController.prototype.findAll,
+} as unknown as ExecutionContext;
+
+const callHandler = (handle: CallHandler["handle"]): CallHandler => ({
+  handle,
+});
+
+describe("WideEventInterceptor", () => {
+  let interceptor: WideEventInterceptor;
+  let traceExporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeAll(() => {
+    traceExporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(traceExporter)],
+    });
+    provider.register();
+  });
+
+  beforeEach(() => {
+    interceptor = new WideEventInterceptor();
+  });
+
+  afterEach(() => {
+    traceExporter.reset();
+  });
+
+  afterAll(async () => {
+    await provider.shutdown();
+  });
+
+  const interceptWithRootSpan = async (
+    handle: CallHandler["handle"],
+    options?: OpenTelemetryModuleOptions
+  ): Promise<unknown> => {
+    const activeInterceptor = options
+      ? new WideEventInterceptor(options)
+      : interceptor;
+    const tracer = trace.getTracer("test");
+    const span = tracer.startSpan("http_request");
+
+    try {
+      return await context.with(
+        trace.setSpan(context.active(), span),
+        async () =>
+          await lastValueFrom(
+            activeInterceptor.intercept(executionContext, callHandler(handle))
+          )
+      );
+    } finally {
+      span.end();
+    }
+  };
+
+  it("should flush handler metadata onto the active span", async () => {
+    const result = await interceptWithRootSpan(() => of("ok"));
+
+    expect(result).toBe("ok");
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.attributes["code.function.name"]).toBe(
+      "CatsController.findAll"
+    );
+  });
+
+  it("should flush attributes set by the service during the request", async () => {
+    const service = new WideEventService();
+
+    await interceptWithRootSpan(() =>
+      defer(() => {
+        service.set("user.id", "u-1");
+        service.increment("db.queries");
+        return of("ok");
+      })
+    );
+
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.attributes["user.id"]).toBe("u-1");
+    expect(span.attributes["db.queries"]).toBe(1);
+  });
+
+  it("should record error attributes when the handler throws", async () => {
+    await expect(
+      interceptWithRootSpan(() => throwError(() => new Error("boom")))
+    ).rejects.toThrow("boom");
+
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.attributes["error.type"]).toBe("Error");
+    expect(span.attributes["error.message"]).toBe("boom");
+  });
+
+  it("should seed attributes from the configured seed callback", async () => {
+    await interceptWithRootSpan(() => of("ok"), {
+      wideEvents: {
+        seed: (ctx) => ({ "app.controller": ctx.getClass().name }),
+      },
+    });
+
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.attributes["app.controller"]).toBe("CatsController");
+  });
+
+  it("should record a seed error without failing the request", async () => {
+    const result = await interceptWithRootSpan(() => of("ok"), {
+      wideEvents: {
+        seed: () => {
+          throw new Error("seed boom");
+        },
+      },
+    });
+
+    expect(result).toBe("ok");
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.attributes["wide_event.seed.error"]).toBe("seed boom");
+  });
+
+  it("should propagate the handler result untouched when no span is active", async () => {
+    const result = await lastValueFrom(
+      interceptor.intercept(
+        executionContext,
+        callHandler(() => of("ok"))
+      )
+    );
+
+    expect(result).toBe("ok");
+    expect(traceExporter.getFinishedSpans()).toHaveLength(0);
+  });
+});

--- a/src/wide-events/wide-event.interceptor.spec.ts
+++ b/src/wide-events/wide-event.interceptor.spec.ts
@@ -7,8 +7,10 @@ import {
 } from "@opentelemetry/sdk-trace-node";
 import { defer, lastValueFrom, Observable, of, throwError } from "rxjs";
 import type { OpenTelemetryModuleOptions } from "../interfaces";
+import { WIDE_EVENT_ROOT_SPAN } from "./wide-event.context";
 import { WideEventInterceptor } from "./wide-event.interceptor";
 import { WideEventService } from "./wide-event.service";
+import { WideEventSpanProcessor } from "./wide-event.span-processor";
 
 class CatsController {
   findAll() {}
@@ -79,6 +81,48 @@ describe("WideEventInterceptor", () => {
     expect(span.attributes["code.function.name"]).toBe(
       "CatsController.findAll"
     );
+  });
+
+  it("should mark the span as a wide event on flush", async () => {
+    await interceptWithRootSpan(() => of("ok"));
+
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.attributes["nestjs_otel.wide_event"]).toBe(true);
+  });
+
+  it("should not let a handler-set field override the wide event marker", async () => {
+    const service = new WideEventService();
+
+    await interceptWithRootSpan(() =>
+      defer(() => {
+        service.set("nestjs_otel.wide_event", false);
+        return of("ok");
+      })
+    );
+
+    const [span] = traceExporter.getFinishedSpans();
+    expect(span.attributes["nestjs_otel.wide_event"]).toBe(true);
+  });
+
+  it("should not mark the span when the observable is unsubscribed before completion", async () => {
+    const span = trace.getTracer("test").startSpan("http_request");
+    const neverCompletes = new Observable((s) => {
+      s.next("partial");
+    });
+
+    const obs$ = context.with(trace.setSpan(context.active(), span), () =>
+      interceptor.intercept(
+        executionContext,
+        callHandler(() => neverCompletes)
+      )
+    );
+
+    const sub = obs$.subscribe();
+    sub.unsubscribe();
+    span.end();
+
+    const [finished] = traceExporter.getFinishedSpans();
+    expect(finished.attributes["nestjs_otel.wide_event"]).toBeUndefined();
   });
 
   it("should flush attributes set by the service during the request", async () => {
@@ -201,6 +245,150 @@ describe("WideEventInterceptor", () => {
     expect(result).toBe("ok");
     const [span] = traceExporter.getFinishedSpans();
     expect(span.attributes["wide_event.seed.error"]).toBeUndefined();
+  });
+
+  it("should flush onto the request root span instead of the nested active span", async () => {
+    // #given
+    const tracer = trace.getTracer("test");
+    const rootSpan = tracer.startSpan("http_request");
+    const req: Record<symbol, unknown> = {
+      [WIDE_EVENT_ROOT_SPAN]: rootSpan,
+    };
+    const httpExecutionContext = {
+      getClass: () => CatsController,
+      getHandler: () => CatsController.prototype.findAll,
+      getType: () => "http",
+      switchToHttp: () => ({ getRequest: () => req }),
+    } as unknown as ExecutionContext;
+
+    // #when: run the interceptor inside a DIFFERENT (nested) active span
+    const nestedSpan = tracer.startSpan("nested_interceptor_span");
+    await context.with(trace.setSpan(context.active(), nestedSpan), async () =>
+      lastValueFrom(
+        interceptor.intercept(
+          httpExecutionContext,
+          callHandler(() => of("ok"))
+        )
+      )
+    );
+    nestedSpan.end();
+    rootSpan.end();
+
+    // #then: marker + metadata land on the root span, not the nested one
+    const finished = traceExporter.getFinishedSpans();
+    const root = finished.find((s) => s.name === "http_request");
+    const nested = finished.find((s) => s.name === "nested_interceptor_span");
+    expect(root?.attributes["nestjs_otel.wide_event"]).toBe(true);
+    expect(root?.attributes["code.function.name"]).toBe(
+      "CatsController.findAll"
+    );
+    expect(nested?.attributes["nestjs_otel.wide_event"]).toBeUndefined();
+  });
+
+  it("should read the root span from request.raw (Fastify) when absent on the request", async () => {
+    // #given: Fastify middie sets the span on the raw IncomingMessage, while
+    // switchToHttp().getRequest() returns the FastifyRequest wrapper.
+    const tracer = trace.getTracer("test");
+    const rootSpan = tracer.startSpan("http_request");
+    const fastifyRequest = { raw: { [WIDE_EVENT_ROOT_SPAN]: rootSpan } };
+    const httpExecutionContext = {
+      getClass: () => CatsController,
+      getHandler: () => CatsController.prototype.findAll,
+      getType: () => "http",
+      switchToHttp: () => ({ getRequest: () => fastifyRequest }),
+    } as unknown as ExecutionContext;
+
+    // #when: run inside a different nested active span
+    const nestedSpan = tracer.startSpan("nested_span");
+    await context.with(trace.setSpan(context.active(), nestedSpan), async () =>
+      lastValueFrom(
+        interceptor.intercept(
+          httpExecutionContext,
+          callHandler(() => of("ok"))
+        )
+      )
+    );
+    nestedSpan.end();
+    rootSpan.end();
+
+    // #then
+    const finished = traceExporter.getFinishedSpans();
+    const root = finished.find((s) => s.name === "http_request");
+    const nested = finished.find((s) => s.name === "nested_span");
+    expect(root?.attributes["nestjs_otel.wide_event"]).toBe(true);
+    expect(nested?.attributes["nestjs_otel.wide_event"]).toBeUndefined();
+  });
+
+  it("should fall back to the active span when the request root span already ended", async () => {
+    // #given: an ephemeral root span (e.g. @fastify/otel phase span) that ends
+    // before the flush runs, plus a live nested active span.
+    const tracer = trace.getTracer("test");
+    const endedRootSpan = tracer.startSpan("ephemeral_phase_span");
+    endedRootSpan.end();
+    const fastifyRequest = { raw: { [WIDE_EVENT_ROOT_SPAN]: endedRootSpan } };
+    const httpExecutionContext = {
+      getClass: () => CatsController,
+      getHandler: () => CatsController.prototype.findAll,
+      getType: () => "http",
+      switchToHttp: () => ({ getRequest: () => fastifyRequest }),
+    } as unknown as ExecutionContext;
+
+    const activeSpan = tracer.startSpan("handler_span");
+    await context.with(trace.setSpan(context.active(), activeSpan), async () =>
+      lastValueFrom(
+        interceptor.intercept(
+          httpExecutionContext,
+          callHandler(() => of("ok"))
+        )
+      )
+    );
+    activeSpan.end();
+
+    // #then: marker lands on the live active span, not the ended root span
+    const finished = traceExporter.getFinishedSpans();
+    const active = finished.find((s) => s.name === "handler_span");
+    const ended = finished.find((s) => s.name === "ephemeral_phase_span");
+    expect(active?.attributes["nestjs_otel.wide_event"]).toBe(true);
+    expect(active?.attributes["code.function.name"]).toBe(
+      "CatsController.findAll"
+    );
+    expect(ended?.attributes["nestjs_otel.wide_event"]).toBeUndefined();
+  });
+
+  it("should prefer the processor's local-root span over the active span", async () => {
+    // #given: a registered local-root span plus a nested active span in the
+    // same trace (as instrumentation-nestjs-core would create).
+    const processor = new WideEventSpanProcessor();
+    const tracer = trace.getTracer("test");
+    const rootSpan = tracer.startSpan("GET /actors");
+    processor.onStart(rootSpan as never, {} as never);
+    const childContext = trace.setSpan(context.active(), rootSpan);
+    const nestedSpan = tracer.startSpan(
+      "ActorController.findAll",
+      undefined,
+      childContext
+    );
+
+    await context.with(trace.setSpan(context.active(), nestedSpan), async () =>
+      lastValueFrom(
+        interceptor.intercept(
+          executionContext,
+          callHandler(() => of("ok"))
+        )
+      )
+    );
+    nestedSpan.end();
+    rootSpan.end();
+
+    // #then: marker lands on the local-root span, not the nested span
+    const finished = traceExporter.getFinishedSpans();
+    const root = finished.find((s) => s.name === "GET /actors");
+    const nested = finished.find((s) => s.name === "ActorController.findAll");
+    expect(root?.attributes["nestjs_otel.wide_event"]).toBe(true);
+    expect(root?.attributes["code.function.name"]).toBe(
+      "CatsController.findAll"
+    );
+    expect(nested?.attributes["nestjs_otel.wide_event"]).toBeUndefined();
   });
 
   it("should propagate the handler result untouched when no span is active", async () => {

--- a/src/wide-events/wide-event.interceptor.ts
+++ b/src/wide-events/wide-event.interceptor.ts
@@ -13,8 +13,15 @@ import type { OpenTelemetryModuleOptions } from "../interfaces";
 import { OPENTELEMETRY_MODULE_OPTIONS } from "../opentelemetry.constants";
 import {
   WIDE_EVENT_CONTEXT_KEY,
+  WIDE_EVENT_ROOT_SPAN,
   type WideEventBag,
 } from "./wide-event.context";
+import { getLocalRootSpan } from "./wide-event.span-processor";
+
+interface RequestWithRootSpan {
+  [WIDE_EVENT_ROOT_SPAN]?: Span;
+  raw?: { [WIDE_EVENT_ROOT_SPAN]?: Span };
+}
 
 /**
  * Opens a wide event for each request and flushes the accumulated
@@ -46,7 +53,14 @@ export class WideEventInterceptor implements NestInterceptor {
     this.seed(bag, executionContext);
 
     const activeContext = context.active();
-    const span = trace.getSpan(activeContext);
+    // The middleware-captured span is the local root on Express / plain
+    // Fastify (alive until the response ends). On stacks that wrap each
+    // request phase in its own span (e.g. @fastify/otel) it can be an
+    // ephemeral span that has already ended by flush time, so we keep the
+    // interceptor-time active span as a live fallback and pick whichever is
+    // still recording when we flush.
+    const rootSpan = this.rootSpanFromRequest(executionContext);
+    const activeSpan = trace.getSpan(activeContext);
     const contextWithBag = activeContext.setValue(WIDE_EVENT_CONTEXT_KEY, bag);
 
     return new Observable((subscriber) => {
@@ -70,7 +84,9 @@ export class WideEventInterceptor implements NestInterceptor {
                     bag.set("error.stack", error.stack);
                   }
                 }
-                span?.setStatus({ code: SpanStatusCode.ERROR });
+                this.targetSpan(rootSpan, activeSpan)?.setStatus({
+                  code: SpanStatusCode.ERROR,
+                });
               },
               complete: () => {
                 terminated = true;
@@ -78,7 +94,7 @@ export class WideEventInterceptor implements NestInterceptor {
             }),
             finalize(() => {
               if (terminated) {
-                this.flush(bag, span);
+                this.flush(bag, rootSpan, activeSpan);
               }
             })
           )
@@ -86,6 +102,46 @@ export class WideEventInterceptor implements NestInterceptor {
       );
       return () => subscription.unsubscribe();
     });
+  }
+
+  private rootSpanFromRequest(
+    executionContext: ExecutionContext
+  ): Span | undefined {
+    if (
+      typeof executionContext.getType !== "function" ||
+      executionContext.getType() !== "http"
+    ) {
+      return;
+    }
+    const request = executionContext
+      .switchToHttp()
+      .getRequest<RequestWithRootSpan | undefined>();
+    return (request?.[WIDE_EVENT_ROOT_SPAN] ??
+      request?.raw?.[WIDE_EVENT_ROOT_SPAN]) as Span | undefined;
+  }
+
+  /**
+   * Picks the span the wide event should be written to, preferring the
+   * local-root span (when the WideEventSpanProcessor is registered), then the
+   * middleware-captured root span, then the interceptor-time active span —
+   * skipping any that have already ended.
+   */
+  private targetSpan(
+    rootSpan: Span | undefined,
+    activeSpan: Span | undefined
+  ): Span | undefined {
+    const traceId = (activeSpan ?? rootSpan)?.spanContext().traceId;
+    const localRoot = traceId ? getLocalRootSpan(traceId) : undefined;
+    return this.pickSpan(localRoot, rootSpan, activeSpan);
+  }
+
+  private pickSpan(...candidates: (Span | undefined)[]): Span | undefined {
+    for (const candidate of candidates) {
+      if (candidate?.isRecording()) {
+        return candidate;
+      }
+    }
+    return;
   }
 
   private seed(bag: WideEventBag, executionContext: ExecutionContext): void {
@@ -111,7 +167,16 @@ export class WideEventInterceptor implements NestInterceptor {
     }
   }
 
-  private flush(bag: WideEventBag, span: Span | undefined): void {
-    span?.setAttributes(Object.fromEntries(bag));
+  private flush(
+    bag: WideEventBag,
+    rootSpan: Span | undefined,
+    activeSpan: Span | undefined
+  ): void {
+    const span = this.targetSpan(rootSpan, activeSpan);
+    if (!span) {
+      return;
+    }
+    span.setAttributes(Object.fromEntries(bag));
+    span.setAttribute("nestjs_otel.wide_event", true);
   }
 }

--- a/src/wide-events/wide-event.interceptor.ts
+++ b/src/wide-events/wide-event.interceptor.ts
@@ -1,0 +1,98 @@
+import {
+  type CallHandler,
+  type ExecutionContext,
+  Inject,
+  Injectable,
+  type NestInterceptor,
+  Optional,
+} from "@nestjs/common";
+import { context, type Span, trace } from "@opentelemetry/api";
+import { Observable } from "rxjs";
+import { finalize, tap } from "rxjs/operators";
+import type { OpenTelemetryModuleOptions } from "../interfaces";
+import { OPENTELEMETRY_MODULE_OPTIONS } from "../opentelemetry.constants";
+import {
+  WIDE_EVENT_CONTEXT_KEY,
+  type WideEventBag,
+} from "./wide-event.context";
+
+/**
+ * Opens a wide event for each request and flushes the accumulated
+ * attributes onto the span that was active when the request entered the
+ * interceptor (usually the root HTTP span created by instrumentation).
+ *
+ * Register globally with APP_INTERCEPTOR or per controller with
+ * UseInterceptors.
+ *
+ * @publicApi
+ */
+@Injectable()
+export class WideEventInterceptor implements NestInterceptor {
+  constructor(
+    @Optional()
+    @Inject(OPENTELEMETRY_MODULE_OPTIONS)
+    private readonly options?: OpenTelemetryModuleOptions
+  ) {}
+
+  intercept(
+    executionContext: ExecutionContext,
+    next: CallHandler
+  ): Observable<unknown> {
+    const bag: WideEventBag = new Map();
+    bag.set(
+      "code.function.name",
+      `${executionContext.getClass().name}.${executionContext.getHandler().name}`
+    );
+    this.seed(bag, executionContext);
+
+    const activeContext = context.active();
+    const span = trace.getSpan(activeContext);
+    const contextWithBag = activeContext.setValue(WIDE_EVENT_CONTEXT_KEY, bag);
+
+    return new Observable((subscriber) => {
+      const subscription = context.with(contextWithBag, () =>
+        next
+          .handle()
+          .pipe(
+            tap({
+              error: (error: unknown) => {
+                bag.set(
+                  "error.type",
+                  error instanceof Error ? error.constructor.name : "unknown"
+                );
+                if (error instanceof Error) {
+                  bag.set("error.message", error.message);
+                }
+              },
+            }),
+            finalize(() => this.flush(bag, span))
+          )
+          .subscribe(subscriber)
+      );
+      return () => subscription.unsubscribe();
+    });
+  }
+
+  private seed(bag: WideEventBag, executionContext: ExecutionContext): void {
+    const seed = this.options?.wideEvents?.seed;
+    if (!seed) {
+      return;
+    }
+    try {
+      for (const [key, value] of Object.entries(seed(executionContext))) {
+        if (value !== undefined) {
+          bag.set(key, value);
+        }
+      }
+    } catch (error) {
+      bag.set(
+        "wide_event.seed.error",
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  }
+
+  private flush(bag: WideEventBag, span: Span | undefined): void {
+    span?.setAttributes(Object.fromEntries(bag));
+  }
+}

--- a/src/wide-events/wide-event.interceptor.ts
+++ b/src/wide-events/wide-event.interceptor.ts
@@ -6,7 +6,7 @@ import {
   type NestInterceptor,
   Optional,
 } from "@nestjs/common";
-import { context, type Span, trace } from "@opentelemetry/api";
+import { context, type Span, SpanStatusCode, trace } from "@opentelemetry/api";
 import { Observable } from "rxjs";
 import { finalize, tap } from "rxjs/operators";
 import type { OpenTelemetryModuleOptions } from "../interfaces";
@@ -50,22 +50,37 @@ export class WideEventInterceptor implements NestInterceptor {
     const contextWithBag = activeContext.setValue(WIDE_EVENT_CONTEXT_KEY, bag);
 
     return new Observable((subscriber) => {
+      let terminated = false;
       const subscription = context.with(contextWithBag, () =>
         next
           .handle()
           .pipe(
             tap({
               error: (error: unknown) => {
+                terminated = true;
                 bag.set(
                   "error.type",
-                  error instanceof Error ? error.constructor.name : "unknown"
+                  error instanceof Error
+                    ? (error.constructor?.name ?? "Error")
+                    : "unknown"
                 );
                 if (error instanceof Error) {
                   bag.set("error.message", error.message);
+                  if (error.stack) {
+                    bag.set("error.stack", error.stack);
+                  }
                 }
+                span?.setStatus({ code: SpanStatusCode.ERROR });
+              },
+              complete: () => {
+                terminated = true;
               },
             }),
-            finalize(() => this.flush(bag, span))
+            finalize(() => {
+              if (terminated) {
+                this.flush(bag, span);
+              }
+            })
           )
           .subscribe(subscriber)
       );
@@ -79,7 +94,11 @@ export class WideEventInterceptor implements NestInterceptor {
       return;
     }
     try {
-      for (const [key, value] of Object.entries(seed(executionContext))) {
+      const result = seed(executionContext);
+      if (result == null) {
+        return;
+      }
+      for (const [key, value] of Object.entries(result)) {
         if (value !== undefined) {
           bag.set(key, value);
         }

--- a/src/wide-events/wide-event.middleware.spec.ts
+++ b/src/wide-events/wide-event.middleware.spec.ts
@@ -1,0 +1,58 @@
+import { context, trace } from "@opentelemetry/api";
+import {
+  InMemorySpanExporter,
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import { WIDE_EVENT_ROOT_SPAN } from "./wide-event.context";
+import { WideEventMiddleware } from "./wide-event.middleware";
+
+describe("WideEventMiddleware", () => {
+  let middleware: WideEventMiddleware;
+  let provider: NodeTracerProvider;
+
+  beforeAll(() => {
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(new InMemorySpanExporter())],
+    });
+    provider.register();
+  });
+
+  beforeEach(() => {
+    middleware = new WideEventMiddleware();
+  });
+
+  afterAll(async () => {
+    await provider.shutdown();
+  });
+
+  it("should stash the active span on the request", () => {
+    // #given
+    const span = trace.getTracer("test").startSpan("http_request");
+    const req: Record<symbol, unknown> = {};
+    const next = jest.fn();
+
+    // #when
+    context.with(trace.setSpan(context.active(), span), () =>
+      middleware.use(req, {}, next)
+    );
+    span.end();
+
+    // #then
+    expect(req[WIDE_EVENT_ROOT_SPAN]).toBe(span);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call next without stashing when no span is active", () => {
+    // #given
+    const req: Record<symbol, unknown> = {};
+    const next = jest.fn();
+
+    // #when
+    middleware.use(req, {}, next);
+
+    // #then
+    expect(req[WIDE_EVENT_ROOT_SPAN]).toBeUndefined();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/wide-events/wide-event.middleware.ts
+++ b/src/wide-events/wide-event.middleware.ts
@@ -1,0 +1,28 @@
+import { Injectable, type NestMiddleware } from "@nestjs/common";
+import { context, trace } from "@opentelemetry/api";
+import { WIDE_EVENT_ROOT_SPAN } from "./wide-event.context";
+
+/**
+ * Captures the span active at the start of the request (the HTTP server /
+ * local-root span, before Nest instrumentation nests guard/interceptor/handler
+ * spans) and stashes it on the request so the WideEventInterceptor can flush
+ * accumulated attributes onto the root span rather than a nested child.
+ *
+ * Applied automatically by the OpenTelemetry module for HTTP apps.
+ *
+ * @publicApi
+ */
+@Injectable()
+export class WideEventMiddleware implements NestMiddleware {
+  use(
+    req: Record<symbol, unknown>,
+    _res: unknown,
+    next: (error?: unknown) => void
+  ): void {
+    const span = trace.getSpan(context.active());
+    if (span) {
+      req[WIDE_EVENT_ROOT_SPAN] = span;
+    }
+    next();
+  }
+}

--- a/src/wide-events/wide-event.service.spec.ts
+++ b/src/wide-events/wide-event.service.spec.ts
@@ -1,0 +1,113 @@
+import { context } from "@opentelemetry/api";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import {
+  WIDE_EVENT_CONTEXT_KEY,
+  type WideEventBag,
+} from "./wide-event.context";
+import { WideEventService } from "./wide-event.service";
+
+describe("WideEventService", () => {
+  let service: WideEventService;
+  let bag: WideEventBag;
+  let provider: NodeTracerProvider;
+
+  const withBag = <T>(fn: () => T): T =>
+    context.with(context.active().setValue(WIDE_EVENT_CONTEXT_KEY, bag), fn);
+
+  beforeAll(() => {
+    provider = new NodeTracerProvider();
+    provider.register();
+  });
+
+  afterAll(async () => {
+    await provider.shutdown();
+  });
+
+  beforeEach(() => {
+    service = new WideEventService();
+    bag = new Map();
+  });
+
+  describe("set", () => {
+    it("should write the attribute to the active bag", () => {
+      withBag(() => service.set("user.id", "u-1"));
+
+      expect(bag.get("user.id")).toBe("u-1");
+    });
+
+    it("should be a no-op when no bag is active", () => {
+      expect(() => service.set("user.id", "u-1")).not.toThrow();
+
+      expect(bag.size).toBe(0);
+    });
+  });
+
+  describe("setMany", () => {
+    it("should write all attributes to the active bag", () => {
+      withBag(() => service.setMany({ "user.id": "u-1", "cart.items": 3 }));
+
+      expect(Object.fromEntries(bag)).toEqual({
+        "user.id": "u-1",
+        "cart.items": 3,
+      });
+    });
+
+    it("should skip undefined values", () => {
+      withBag(() => service.setMany({ "user.id": undefined }));
+
+      expect(bag.size).toBe(0);
+    });
+
+    it("should be a no-op when no bag is active", () => {
+      expect(() => service.setMany({ "user.id": "u-1" })).not.toThrow();
+    });
+  });
+
+  describe("increment", () => {
+    it("should start from 0 when the attribute is absent", () => {
+      withBag(() => service.increment("db.queries"));
+
+      expect(bag.get("db.queries")).toBe(1);
+    });
+
+    it("should add to the existing value", () => {
+      withBag(() => {
+        service.increment("db.queries", 2);
+        service.increment("db.queries", 3);
+      });
+
+      expect(bag.get("db.queries")).toBe(5);
+    });
+
+    it("should reset non-numeric values to 0 before adding", () => {
+      bag.set("db.queries", "oops");
+
+      withBag(() => service.increment("db.queries"));
+
+      expect(bag.get("db.queries")).toBe(1);
+    });
+
+    it("should be a no-op when no bag is active", () => {
+      expect(() => service.increment("db.queries")).not.toThrow();
+    });
+  });
+
+  describe("startTimer", () => {
+    it("should record elapsed milliseconds when stopped", () => {
+      withBag(() => {
+        const stop = service.startTimer("db.duration_ms");
+        stop();
+      });
+
+      expect(typeof bag.get("db.duration_ms")).toBe("number");
+      expect(bag.get("db.duration_ms")).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should be a no-op when stopped without an active bag", () => {
+      const stop = service.startTimer("db.duration_ms");
+
+      expect(() => stop()).not.toThrow();
+      expect(bag.size).toBe(0);
+    });
+  });
+});

--- a/src/wide-events/wide-event.service.spec.ts
+++ b/src/wide-events/wide-event.service.spec.ts
@@ -103,6 +103,31 @@ describe("WideEventService", () => {
       expect(bag.get("db.duration_ms")).toBeGreaterThanOrEqual(0);
     });
 
+    it("should accumulate elapsed time when the same key is timed multiple times", () => {
+      // #given
+      let tick = 0;
+      jest.spyOn(performance, "now").mockImplementation(() => tick);
+
+      withBag(() => {
+        // #when — first timer: 10ms
+        tick = 0;
+        const stop1 = service.startTimer("db.duration_ms");
+        tick = 10;
+        stop1();
+
+        // second timer: 25ms
+        tick = 100;
+        const stop2 = service.startTimer("db.duration_ms");
+        tick = 125;
+        stop2();
+      });
+
+      // #then
+      expect(bag.get("db.duration_ms")).toBe(35);
+
+      jest.restoreAllMocks();
+    });
+
     it("should be a no-op when stopped without an active bag", () => {
       const stop = service.startTimer("db.duration_ms");
 

--- a/src/wide-events/wide-event.service.ts
+++ b/src/wide-events/wide-event.service.ts
@@ -52,9 +52,15 @@ export class WideEventService {
    * the timer and records the elapsed time in milliseconds.
    */
   startTimer(key: string): () => void {
+    const bag = getWideEventBag();
     const start = performance.now();
     return () => {
-      getWideEventBag()?.set(key, performance.now() - start);
+      if (!bag) {
+        return;
+      }
+      const elapsed = performance.now() - start;
+      const current = bag.get(key);
+      bag.set(key, (typeof current === "number" ? current : 0) + elapsed);
     };
   }
 }

--- a/src/wide-events/wide-event.service.ts
+++ b/src/wide-events/wide-event.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from "@nestjs/common";
+import type { Attributes, AttributeValue } from "@opentelemetry/api";
+import { getWideEventBag } from "./wide-event.context";
+
+/**
+ * Accumulates attributes for the wide event of the current request.
+ *
+ * All methods are no-ops when called outside a request handled by the
+ * WideEventInterceptor.
+ *
+ * @publicApi
+ */
+@Injectable()
+export class WideEventService {
+  /**
+   * Set a single attribute on the current wide event.
+   */
+  set(key: string, value: AttributeValue): void {
+    getWideEventBag()?.set(key, value);
+  }
+
+  /**
+   * Set multiple attributes on the current wide event.
+   */
+  setMany(attributes: Attributes): void {
+    const bag = getWideEventBag();
+    if (!bag) {
+      return;
+    }
+    for (const [key, value] of Object.entries(attributes)) {
+      if (value !== undefined) {
+        bag.set(key, value);
+      }
+    }
+  }
+
+  /**
+   * Increment a numeric attribute on the current wide event.
+   * Starts from 0 when the attribute is absent or not a number.
+   */
+  increment(key: string, by = 1): void {
+    const bag = getWideEventBag();
+    if (!bag) {
+      return;
+    }
+    const current = bag.get(key);
+    bag.set(key, (typeof current === "number" ? current : 0) + by);
+  }
+
+  /**
+   * Start a timer for the given attribute. The returned function stops
+   * the timer and records the elapsed time in milliseconds.
+   */
+  startTimer(key: string): () => void {
+    const start = performance.now();
+    return () => {
+      getWideEventBag()?.set(key, performance.now() - start);
+    };
+  }
+}

--- a/src/wide-events/wide-event.span-processor.spec.ts
+++ b/src/wide-events/wide-event.span-processor.spec.ts
@@ -1,0 +1,66 @@
+import { context, trace } from "@opentelemetry/api";
+import { NodeTracerProvider, type Span } from "@opentelemetry/sdk-trace-node";
+import {
+  getLocalRootSpan,
+  WideEventSpanProcessor,
+} from "./wide-event.span-processor";
+
+describe("WideEventSpanProcessor", () => {
+  let processor: WideEventSpanProcessor;
+  let provider: NodeTracerProvider;
+
+  beforeAll(() => {
+    provider = new NodeTracerProvider();
+    provider.register();
+  });
+
+  beforeEach(() => {
+    processor = new WideEventSpanProcessor();
+  });
+
+  afterAll(async () => {
+    await provider.shutdown();
+  });
+
+  const startSpan = (name: string): Span =>
+    trace.getTracer("test").startSpan(name) as Span;
+
+  it("should register a parentless span as the local root for its trace", () => {
+    const root = startSpan("GET /test");
+
+    processor.onStart(root, context.active());
+
+    expect(getLocalRootSpan(root.spanContext().traceId)).toBe(root);
+    root.end();
+  });
+
+  it("should not register a span whose parent is local", () => {
+    const root = startSpan("GET /test");
+    processor.onStart(root, context.active());
+    const child = trace
+      .getTracer("test")
+      .startSpan(
+        "child",
+        undefined,
+        trace.setSpan(context.active(), root)
+      ) as Span;
+
+    processor.onStart(child, context.active());
+
+    // local root for the trace is still the root, not the child
+    expect(getLocalRootSpan(root.spanContext().traceId)).toBe(root);
+    child.end();
+    root.end();
+  });
+
+  it("should drop the local root from the registry when it ends", () => {
+    const root = startSpan("GET /test");
+    const traceId = root.spanContext().traceId;
+    processor.onStart(root, context.active());
+
+    processor.onEnd(root);
+
+    expect(getLocalRootSpan(traceId)).toBeUndefined();
+    root.end();
+  });
+});

--- a/src/wide-events/wide-event.span-processor.ts
+++ b/src/wide-events/wide-event.span-processor.ts
@@ -1,0 +1,67 @@
+import type { Context } from "@opentelemetry/api";
+import type {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+const localRootSpans = new Map<string, Span>();
+
+const isLocalRoot = (span: ReadableSpan): boolean => {
+  const parent = span.parentSpanContext;
+  return !parent || parent.isRemote === true;
+};
+
+/**
+ * The local-root span for the given trace (the span with no in-process
+ * parent — usually the HTTP server span created by instrumentation), or
+ * undefined when the WideEventSpanProcessor is not registered or the span has
+ * already ended.
+ *
+ * @internal
+ */
+export function getLocalRootSpan(traceId: string): Span | undefined {
+  return localRootSpans.get(traceId);
+}
+
+/**
+ * Tracks the local-root span of every trace so the WideEventInterceptor can
+ * flush accumulated attributes onto it instead of a nested instrumentation
+ * span (e.g. the per-request span created by instrumentation-nestjs-core or
+ * the per-phase spans created by @fastify/otel).
+ *
+ * Register it on your NodeSDK alongside the exporting processor:
+ *
+ * ```ts
+ * new NodeSDK({
+ *   spanProcessors: [
+ *     new WideEventSpanProcessor(),
+ *     new BatchSpanProcessor(traceExporter),
+ *   ],
+ * });
+ * ```
+ *
+ * @publicApi
+ */
+export class WideEventSpanProcessor implements SpanProcessor {
+  onStart(span: Span, _parentContext: Context): void {
+    if (isLocalRoot(span)) {
+      localRootSpans.set(span.spanContext().traceId, span);
+    }
+  }
+
+  onEnd(span: ReadableSpan): void {
+    if (isLocalRoot(span)) {
+      localRootSpans.delete(span.spanContext().traceId);
+    }
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  shutdown(): Promise<void> {
+    localRootSpans.clear();
+    return Promise.resolve();
+  }
+}

--- a/tests/e2e/wide-events/wide-event.autowire-fastify.spec.ts
+++ b/tests/e2e/wide-events/wide-event.autowire-fastify.spec.ts
@@ -1,0 +1,46 @@
+import { type INestApplication, Module } from "@nestjs/common";
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import {
+  FastifyAdapter,
+  type NestFastifyApplication,
+} from "@nestjs/platform-fastify";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+import { OpenTelemetryModule, WideEventInterceptor } from "../../../src";
+import { WideEventMiddleware } from "../../../src/wide-events/wide-event.middleware";
+import { WideEventController } from "../../fixture-app/wide-event.controller";
+
+@Module({
+  imports: [OpenTelemetryModule.forRoot()],
+  controllers: [WideEventController],
+  providers: [{ provide: APP_INTERCEPTOR, useClass: WideEventInterceptor }],
+})
+class TestModule {}
+
+describe("Wide Events auto-wired middleware (Fastify)", () => {
+  let app: INestApplication;
+  const useSpy = jest.spyOn(WideEventMiddleware.prototype, "use");
+
+  beforeAll(async () => {
+    const testingModule = await Test.createTestingModule({
+      imports: [TestModule],
+    }).compile();
+    app = testingModule.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter()
+    );
+    await app.init();
+    await (app as NestFastifyApplication).getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("should run WideEventMiddleware on Fastify without manual wiring", async () => {
+    useSpy.mockClear();
+
+    await request(app.getHttpServer()).get("/wide-event/enrich").expect(200);
+
+    expect(useSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/e2e/wide-events/wide-event.autowire.spec.ts
+++ b/tests/e2e/wide-events/wide-event.autowire.spec.ts
@@ -1,0 +1,39 @@
+import { type INestApplication, Module } from "@nestjs/common";
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+import { OpenTelemetryModule, WideEventInterceptor } from "../../../src";
+import { WideEventMiddleware } from "../../../src/wide-events/wide-event.middleware";
+import { WideEventController } from "../../fixture-app/wide-event.controller";
+
+@Module({
+  imports: [OpenTelemetryModule.forRoot()],
+  controllers: [WideEventController],
+  providers: [{ provide: APP_INTERCEPTOR, useClass: WideEventInterceptor }],
+})
+class TestModule {}
+
+describe("Wide Events auto-wired middleware", () => {
+  let app: INestApplication;
+  const useSpy = jest.spyOn(WideEventMiddleware.prototype, "use");
+
+  beforeAll(async () => {
+    const testingModule = await Test.createTestingModule({
+      imports: [TestModule],
+    }).compile();
+    app = testingModule.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("should run WideEventMiddleware without any manual middleware wiring", async () => {
+    useSpy.mockClear();
+
+    await request(app.getHttpServer()).get("/wide-event/enrich").expect(200);
+
+    expect(useSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/e2e/wide-events/wide-event.fastify.spec.ts
+++ b/tests/e2e/wide-events/wide-event.fastify.spec.ts
@@ -1,0 +1,117 @@
+import {
+  type INestApplication,
+  Injectable,
+  type MiddlewareConsumer,
+  Module,
+  type NestMiddleware,
+  type NestModule,
+} from "@nestjs/common";
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import {
+  FastifyAdapter,
+  type NestFastifyApplication,
+} from "@nestjs/platform-fastify";
+import { Test } from "@nestjs/testing";
+import { context, trace } from "@opentelemetry/api";
+import {
+  InMemorySpanExporter,
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import request from "supertest";
+import { OpenTelemetryModule, WideEventInterceptor } from "../../../src";
+import { WideEventController } from "../../fixture-app/wide-event.controller";
+
+@Injectable()
+class RootSpanMiddleware implements NestMiddleware {
+  use(
+    _req: unknown,
+    res: { on: (e: string, cb: () => void) => void },
+    next: () => void
+  ) {
+    const span = trace.getTracer("test").startSpan("http_request");
+
+    context.with(trace.setSpan(context.active(), span), () => {
+      res.on("finish", () => span.end());
+      next();
+    });
+  }
+}
+
+@Module({
+  imports: [OpenTelemetryModule.forRoot()],
+  controllers: [WideEventController],
+  providers: [{ provide: APP_INTERCEPTOR, useClass: WideEventInterceptor }],
+})
+class TestModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(RootSpanMiddleware).forRoutes("*");
+  }
+}
+
+describe("Wide Events (Fastify)", () => {
+  let app: INestApplication;
+  let traceExporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeAll(async () => {
+    traceExporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(traceExporter)],
+    });
+    provider.register();
+
+    const testingModule = await Test.createTestingModule({
+      imports: [TestModule],
+    }).compile();
+
+    app = testingModule.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter()
+    );
+    await app.init();
+    await (app as NestFastifyApplication)
+      .getHttpAdapter()
+      .getInstance()
+      .ready();
+  });
+
+  afterEach(() => {
+    traceExporter.reset();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await provider.shutdown();
+  });
+
+  const getRootSpan = () =>
+    traceExporter.getFinishedSpans().find((s) => s.name === "http_request");
+
+  it("should flush accumulated attributes onto the root span", async () => {
+    await request(app.getHttpServer()).get("/wide-event/enrich").expect(200);
+
+    const rootSpan = getRootSpan();
+    expect(rootSpan).toBeDefined();
+    expect(rootSpan?.attributes).toEqual(
+      expect.objectContaining({
+        "code.function.name": "WideEventController.enrich",
+        "user.id": "u-1",
+        "db.queries": 2,
+        "nestjs_otel.wide_event": true,
+      })
+    );
+  });
+
+  it("should flush error attributes alongside accumulated ones", async () => {
+    await request(app.getHttpServer()).get("/wide-event/error").expect(500);
+
+    const rootSpan = getRootSpan();
+    expect(rootSpan?.attributes).toEqual(
+      expect.objectContaining({
+        "user.id": "u-2",
+        "error.type": "Error",
+        "error.message": "wide event error",
+      })
+    );
+  });
+});

--- a/tests/e2e/wide-events/wide-event.spec.ts
+++ b/tests/e2e/wide-events/wide-event.spec.ts
@@ -1,0 +1,143 @@
+import {
+  type INestApplication,
+  Injectable,
+  type MiddlewareConsumer,
+  Module,
+  type NestMiddleware,
+  type NestModule,
+} from "@nestjs/common";
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import { Test } from "@nestjs/testing";
+import { context, trace } from "@opentelemetry/api";
+import {
+  InMemorySpanExporter,
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-node";
+import type { NextFunction, Request, Response } from "express";
+import request from "supertest";
+import { OpenTelemetryModule, WideEventInterceptor } from "../../../src";
+import { WideEventController } from "../../fixture-app/wide-event.controller";
+
+@Injectable()
+class RootSpanMiddleware implements NestMiddleware {
+  use(_req: Request, res: Response, next: NextFunction) {
+    const tracer = trace.getTracer("test");
+    const span = tracer.startSpan("http_request");
+
+    context.with(trace.setSpan(context.active(), span), () => {
+      res.on("finish", () => {
+        span.end();
+      });
+      next();
+    });
+  }
+}
+
+@Module({
+  imports: [
+    OpenTelemetryModule.forRoot({
+      wideEvents: {
+        seed: (ctx) => ({
+          "http.method": ctx.switchToHttp().getRequest().method,
+        }),
+      },
+    }),
+  ],
+  controllers: [WideEventController],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: WideEventInterceptor,
+    },
+  ],
+})
+class TestModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(RootSpanMiddleware).forRoutes("*");
+  }
+}
+
+describe("Wide Events", () => {
+  let app: INestApplication;
+  let traceExporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeAll(async () => {
+    traceExporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(traceExporter)],
+    });
+    provider.register();
+
+    const testingModule = await Test.createTestingModule({
+      imports: [TestModule],
+    }).compile();
+
+    app = testingModule.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(() => {
+    traceExporter.reset();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await provider.shutdown();
+  });
+
+  const getRootSpan = () =>
+    traceExporter.getFinishedSpans().find((s) => s.name === "http_request");
+
+  it("should flush accumulated attributes onto the root span", async () => {
+    await request(app.getHttpServer()).get("/wide-event/enrich").expect(200);
+
+    const rootSpan = getRootSpan();
+    expect(rootSpan).toBeDefined();
+    expect(rootSpan?.attributes).toEqual(
+      expect.objectContaining({
+        "code.function.name": "WideEventController.enrich",
+        "user.id": "u-1",
+        "cart.items": 3,
+        "cart.total": 42.5,
+        "db.queries": 2,
+      })
+    );
+  });
+
+  it("should record timer durations", async () => {
+    await request(app.getHttpServer()).get("/wide-event/timer").expect(200);
+
+    const rootSpan = getRootSpan();
+    expect(typeof rootSpan?.attributes["work.duration_ms"]).toBe("number");
+    expect(rootSpan?.attributes["work.duration_ms"]).toBeGreaterThan(0);
+  });
+
+  it("should flush error attributes alongside accumulated ones", async () => {
+    await request(app.getHttpServer()).get("/wide-event/error").expect(500);
+
+    const rootSpan = getRootSpan();
+    expect(rootSpan?.attributes).toEqual(
+      expect.objectContaining({
+        "user.id": "u-2",
+        "error.type": "Error",
+        "error.message": "wide event error",
+      })
+    );
+  });
+
+  it("should seed attributes from the module seed option", async () => {
+    await request(app.getHttpServer()).get("/wide-event/enrich").expect(200);
+
+    const rootSpan = getRootSpan();
+    expect(rootSpan?.attributes["http.method"]).toBe("GET");
+  });
+
+  it("should capture return values with @WideEventField", async () => {
+    await request(app.getHttpServer()).get("/wide-event/field").expect(200);
+
+    const rootSpan = getRootSpan();
+    expect(rootSpan?.attributes["books.count"]).toBe(2);
+  });
+});

--- a/tests/fixture-app/wide-event.controller.ts
+++ b/tests/fixture-app/wide-event.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get } from "@nestjs/common";
+// biome-ignore lint/style/useImportType: NestJS DI needs the runtime class for design:paramtypes
+import { WideEventService } from "../../src/wide-events/wide-event.service";
+import { WideEventField } from "../../src/wide-events/wide-event-field.decorator";
+
+@Controller("wide-event")
+export class WideEventController {
+  constructor(private readonly wideEventService: WideEventService) {}
+
+  @Get("enrich")
+  enrich() {
+    this.wideEventService.set("user.id", "u-1");
+    this.wideEventService.setMany({ "cart.items": 3, "cart.total": 42.5 });
+    this.wideEventService.increment("db.queries");
+    this.wideEventService.increment("db.queries");
+    return "enriched";
+  }
+
+  @Get("timer")
+  async timer() {
+    const stop = this.wideEventService.startTimer("work.duration_ms");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    stop();
+    return "timed";
+  }
+
+  @Get("error")
+  error() {
+    this.wideEventService.set("user.id", "u-2");
+    throw new Error("wide event error");
+  }
+
+  @Get("field")
+  @WideEventField("books.count", (books: string[]) => books.length)
+  field() {
+    return ["Book 1", "Book 2"];
+  }
+}

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -13,11 +13,11 @@ import { meterData } from "../src/metrics/metric-data";
 
 export type App = INestApplication;
 
-export type TestHarness = {
+export interface TestHarness {
   testingModule: TestingModule;
   app: App;
   agent: TestAgent<request.Test>;
-};
+}
 
 export async function createOpenTelemetryModule(
   module: DynamicModule


### PR DESCRIPTION
Add WideEventService, WideEventInterceptor, and @WideEventField decorator implementing the wide-events (canonical log line) pattern on top of OpenTelemetry. Per request, attributes are accumulated in a context-backed bag and flushed onto the active root span when the request finishes.

- WideEventService: set/setMany/increment/startTimer, safe no-ops outside a request handled by the interceptor
- WideEventInterceptor: seeds code.function.name, records error.type/message on throw, supports a seed callback via the wideEvents module option
- @WideEventField: capture a method return value onto the current wide event
- export OPENTELEMETRY_MODULE_OPTIONS so the interceptor receives module options whether bound via APP_INTERCEPTOR or @UseInterceptors

Convert object type aliases to interfaces in touched files to satisfy the repo's lint gate.